### PR TITLE
Fix build errors when using newer versions of GCC

### DIFF
--- a/src/Input/Component.C
+++ b/src/Input/Component.C
@@ -125,7 +125,7 @@ void Component::getMatLib(istream& input)
   input >> fname;
   matLib.open(searchNonXSPath(fname));
 
-  if (matLib == 0)
+  if (!matLib)
     error(110,"Unable to open material library: %s",fname);
 
   verbose(2,"Openned material library %s",searchNonXSPath(fname));
@@ -137,7 +137,7 @@ void Component::getEleLib(istream& input)
   input >> fname;
   eleLib.open(searchNonXSPath(fname),ios::in);
 
-  if (eleLib == 0)
+  if (!eleLib)
     error(111,"Unable to open element library: %s",fname);
 
   verbose(2,"Openned element library %s",searchNonXSPath(fname));

--- a/src/Input/Geometry.C
+++ b/src/Input/Geometry.C
@@ -18,7 +18,7 @@
  ********* Service *********
  **************************/
 
-Geometry::Geometry(char *token)
+Geometry::Geometry(const char *token)
 {
 
   rMin = -1;

--- a/src/Input/Geometry.h
+++ b/src/Input/Geometry.h
@@ -34,7 +34,7 @@ protected:
 public:
   /// Default constructor defaults to a point geometry if no argument 
   /// is given.
-  Geometry(char *token="p");
+  Geometry(const char *token="p");
 
   /// Default destructor
   ~Geometry() {};

--- a/src/Input/Input.C
+++ b/src/Input/Input.C
@@ -55,7 +55,7 @@ Input::Input(char* inputFname)
     {
       debug(1,"Openning %s for input.",inputFname);
       input = openFile(inputFname);
-      if (*input == NULL)
+      if (!*input)
 	error(102,"Unable to open main input file: '%s'.",inputFname);
 
       verbose(1,"Openned %s for input.",inputFname);
@@ -529,7 +529,7 @@ void Input::clearIncludeComment()
 	     *  - library selection */
 	    input = openFile(searchNonXSPath(inFileName));
 
-	    if (*input == 0)
+	    if (!*input)
 	      error(101,"Unable to open included file: '%s'.",inFileName);
 
 	    verbose(2,"Reading included file: %s.",inFileName);


### PR DESCRIPTION
I was getting various build errors when using GCC 5 and 6. I tested that these changes work on GCC 6.2.