### PR TITLE
Small fix to elemen name length.

### DIFF
--- a/src/Input/Component.C
+++ b/src/Input/Component.C
@@ -248,6 +248,7 @@ Root* Component::expandEle(Mixture* mix, Component* comp)
    * fabricated name.  e.g. enriched Li might be li:90 */
   eleNameLen = strchr(compName,':')-compName;
   if (eleNameLen <= 0) eleNameLen = strlen(compName);
+  if (eleNameLen > 2) eleNameLen = 2;
 
   /* search for this element */
   clearComment(eleLib);


### PR DESCRIPTION
Limits element name lengths to 2. Keeps ALARA from looking for string characters in places where there aren't any. This crops up due to a problem with the way strlen is interpreted for non-null-terminated strings in C. 