### PR TITLE
add compile into gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ depcomp
 install-sh
 missing
 stamp-h1
+compile
 
 src/Util/dflt_datadir.h
 src/alara


### PR DESCRIPTION
Major change:
1. Add `compile` in the `.gitignore`. The `compile` is generated from the `autoreconf`. Ignore it makes repo cleaner. 