### PR TITLE
Redid glossary to use sphinx auto-glossary suppoort

### DIFF
--- a/doc/usersguide/Manual_syntax.rst
+++ b/doc/usersguide/Manual_syntax.rst
@@ -3,9 +3,6 @@ Manual Syntax
 =============
 
 +---------------------------------------+-----------------------------------------------------------+
-| [G]		                        |This icon indicates that a definition exists in the        |
-|					|glossary for this term.                                    |
-+---------------------------------------+-----------------------------------------------------------+
 | :doc:`command line <commandtext>`	|A term written in red text indicates that there is a       |
 |					|section in the manual on this term.                        |
 +---------------------------------------+-----------------------------------------------------------+

--- a/doc/usersguide/Manual_syntax.rst
+++ b/doc/usersguide/Manual_syntax.rst
@@ -3,7 +3,7 @@ Manual Syntax
 =============
 
 +---------------------------------------+-----------------------------------------------------------+
-| :doc:`[G] <glossarytext>`		|This icon indicates that a definition exists in the        |
+| [G]		                        |This icon indicates that a definition exists in the        |
 |					|glossary for this term.                                    |
 +---------------------------------------+-----------------------------------------------------------+
 | :doc:`command line <commandtext>`	|A term written in red text indicates that there is a       |

--- a/doc/usersguide/commandtext.rst
+++ b/doc/usersguide/commandtext.rst
@@ -15,12 +15,12 @@ Options
 
  -h				print a short help message describing the command-line
 
- -r				operate in a :term:`post-processing mode` [G]
+ -r				operate in a :term:`post-processing mode`
 			
 				This option is used to redo the built-in post-processing
 				stage of ALARA, possibly calculating different responses than
 				in the original run. ALARA creates a :term:`dump
-				file` [G] during operation
+				file` during operation
 				which contains enough information to calculate different 
 				output responses for the same problem. This option can 
 				only be used after ALARA has already been successfully 
@@ -39,11 +39,10 @@ Options
  -t <tree_filename>		set the filename for the tree file
 
 				This option defines the name of the optional :term:`tree 
-				file` [G] to be generated during 
+				file` to be generated during 
 				the ALARA run. If it already exists, this file will be 
 				overwritten. For more information on tree files, see the 
-				Users' Guide section devoted to :doc:`output files <outputtext>`
-				[G]. 
+				Users' Guide section devoted to :doc:`output files <outputtext>`. 
 
  -v				show version string 
 
@@ -69,7 +68,7 @@ Options
 				|         |program phase, including basic echoing of input and basic  |
 				|	  |statistics on the solution status.                         |
 				+---------+-----------------------------------------------------------+
-				|   4-6   |Increased :term:`verbosity` [G] gives                      |
+				|   4-6   |Increased :term:`verbosity` gives                          |
 				|	  |more information in input processing and more solution     |
 				|	  |statistics. During input processing, this includes         |
 				|	  |expansion of materials and calculation of interval volumes,|
@@ -78,9 +77,9 @@ Options
 				|	  |status and truncation status.                              |
 				+---------+-----------------------------------------------------------+
 
- <input_filename>		define the :doc:`input file <inputtext>` [G]
+ <input_filename>		define the :doc:`input file <inputtext>` 
 
-				This option defines which :doc:`input file <inputtext>` [G]
+				This option defines which :doc:`input file <inputtext>`
 				will be used. If not name is given, the input will be read from stdin. 
 			
 	

--- a/doc/usersguide/commandtext.rst
+++ b/doc/usersguide/commandtext.rst
@@ -15,12 +15,12 @@ Options
 
  -h				print a short help message describing the command-line
 
- -r				operate in a post-processing mode :doc:`[G] <glossarytext>`
+ -r				operate in a :term:`post-processing mode` [G]
 			
 				This option is used to redo the built-in post-processing
 				stage of ALARA, possibly calculating different responses than
-				in the original run. ALARA creates a dump
-				file :doc:`[G] <glossarytext>` during operation
+				in the original run. ALARA creates a :term:`dump
+				file` [G] during operation
 				which contains enough information to calculate different 
 				output responses for the same problem. This option can 
 				only be used after ALARA has already been successfully 
@@ -38,12 +38,12 @@ Options
 
  -t <tree_filename>		set the filename for the tree file
 
-				This option defines the name of the optional tree 
-				file :doc:`[G] <glossarytext>` to be generated during 
+				This option defines the name of the optional :term:`tree 
+				file` [G] to be generated during 
 				the ALARA run. If it already exists, this file will be 
 				overwritten. For more information on tree files, see the 
 				Users' Guide section devoted to :doc:`output files <outputtext>`
-				:doc:`[G] <glossarytext>`. 
+				[G]. 
 
  -v				show version string 
 
@@ -69,7 +69,7 @@ Options
 				|         |program phase, including basic echoing of input and basic  |
 				|	  |statistics on the solution status.                         |
 				+---------+-----------------------------------------------------------+
-				|   4-6   |Increased verbosity:doc:`[G] <glossarytext>` gives         |
+				|   4-6   |Increased :term:`verbosity` [G] gives                      |
 				|	  |more information in input processing and more solution     |
 				|	  |statistics. During input processing, this includes         |
 				|	  |expansion of materials and calculation of interval volumes,|
@@ -78,9 +78,9 @@ Options
 				|	  |status and truncation status.                              |
 				+---------+-----------------------------------------------------------+
 
- <input_filename>		define the :doc:`input file <inputtext>` :doc:`[G] <glossarytext>`
+ <input_filename>		define the :doc:`input file <inputtext>` [G]
 
-				This option defines which :doc:`input file <inputtext>` :doc:`[G] <glossarytext>`
+				This option defines which :doc:`input file <inputtext>` [G]
 				will be used. If not name is given, the input will be read from stdin. 
 			
 	

--- a/doc/usersguide/errortext.rst
+++ b/doc/usersguide/errortext.rst
@@ -19,8 +19,8 @@ Error Message Types
 Example Error Message:
 ======================
 
-| Error name/number:     130: Invalid :term:`dimension` [G] type: <string> 
-| Description:           The type of :term:`dimension` [G], string,
+| Error name/number:     130: Invalid :term:`dimension` type: <string> 
+| Description:           The type of :term:`dimension`, string,
 		         declared in the dimension block is not supported.
 
 .. _Command-line Parsing:
@@ -35,7 +35,7 @@ Command-line Parsing
 **1: Only one input filename can be specified: <string>.**
 
     There appears to be more than one input filename on the
-    :term:`command-line` [G]. This may be 
+    :term:`command-line`. This may be 
     caused by an error in the other command line options,
     or a missing option.
 
@@ -49,7 +49,7 @@ Input Phase
  an error in the input file, ALARA may not immediately
  recognize the error and then report an error during some
  later input block. This is particularly true during the
- first step, reading the :term:`input file` [G]
+ first step, reading the :term:`input file`
  itself.
 
 .. _Read Input File:
@@ -60,7 +60,7 @@ Read Input File
 **100: Invalid token in input file: <string>**
 
     There is an error in the input file causing it to read
-    an invalid :term:`keyword` [G].
+    an invalid :term:`keyword`.
 
 **101: Unable to open included file: '<string>'.**
 
@@ -79,17 +79,17 @@ Read Input File
 
 **120: Invalid units in cooling time: <time> <units>**
 
-    The specified :term:`cooling time` [G] 
+    The specified :term:`cooling time`
     does not have one of the supported time units.
 
 **121: No after-shutdown/cooling times were defined.**
 
     The cooling input block contains no information before
-    the end :term:`keyword` [G].
+    the end :term:`keyword`.
 
 **130: Invalid dimension type: <string>**
 
-    The type of :term:`dimension` [G], string,
+    The type of :term:`dimension`, string,
     declared in the dimension block is not supported.
 
 **131: Dimension has no boundaries**
@@ -99,7 +99,7 @@ Read Input File
 
 **140: Invalid flux type: <string>**
 
-    The :term:`flux type<flux spectra>` [G], string, specified
+    The :term:`flux type<flux spectra>`, string, specified
     in the flux block in not supported.
 
 **150: Invalid geometry type: <string>**
@@ -110,24 +110,24 @@ Read Input File
 **160: History <string> is empty**
 
     The history input block, string, contains no information
-    before the end :term:`keyword` [G].
+    before the end :term:`keyword`.
 
 **170: Material Loading is empty.**
 
     The mat_loading input block contains no information
-    before the end :term:`keyword` [G].
+    before the end :term:`keyword`.
 
 **180: Target materials for reverse calculations can only be 
 elements or isotopes and not '<string>'**
 
     The constituent type, string, given for this target
     material is not supported. It must be either ''element''
-    or '':term:`isotope` [G]''.
+    or '':term:`isotope`''.
 
 **181: Invalid material constituent: <string>**
 
     The constituent type, string, specified for this
-    :term:`mixture` [G] constituent is not
+    :term:`mixture` constituent is not
     supported.
 
 **182: Mixture <string> has no constituents**
@@ -162,7 +162,7 @@ elements or isotopes and not '<string>'**
 
 **240: Unable to open dump file <string>**
 
-    The output :term:`''dump'' file <dump file>` [G] could not be opened.
+    The output :term:`''dump'' file <dump file>` could not be opened.
 
 .. _Input Checking:
 
@@ -218,17 +218,17 @@ volumes for multi-point problems.**
 **330: Duplicate dimensions of type <string>.**
 
     The dimension string was defined more that
-    once in the :term:`input file` [G].
+    once in the :term:`input file`.
 
 331: <string1> geometries don't have dimensions of type <string2>.
 
     The dimension type string2 was defined for
     geometry type string1, which does not allow
-    this kind of :term:`dimension` [G].
+    this kind of :term:`dimension`.
 
 **340: Unable to open flux file <string1> for flux <string2>.**
 
-    In the :term:`flux` [G] definition
+    In the :term:`flux` definition
     string2 the given flux file string1
     cannot be opened.
 
@@ -236,23 +236,23 @@ volumes for multi-point problems.**
 
     All problems defined as having :term:`toroidal
     geometries <major and minor radii of toroidal 
-    geometries>` [G] must define a :term:`major radius <major and 
+    geometries>` must define a :term:`major radius <major and 
     minor radii of toroidal geometries>` 
-    [G] with the major_radius input block.
+    with the major_radius input block.
 
 **351: Toroidal problems with zone dimensions require either
 a :term:`minor radius <major and minor radii of toroidal geometries>`
-[G] or a radius dimension.**
+or a radius dimension.**
 
     All problems defined as having :term:`toroidal
-    geometries <major and minor radii of toroidal geometries>` [G] must define
+    geometries <major and minor radii of toroidal geometries>` must define
     a minor radius with either a dimension block
     or the minor_radius input block.
 
 **370: Zone <string1> is loaded with a non-existent 
 mixture: <string2>**
 
-    The :term:`mixture` [G] string2
+    The :term:`mixture` string2
     specified to fill zone string1 in the mat_loading
     block is not defined in the input file. Either
     add a new mixture definition or change the name
@@ -308,10 +308,10 @@ item of schedule <string>.**
     The pulsing history string1 required to calculate
     a schedule item of schedule string2 has not been defined.
 
-**420: :term:`Zone <zones>`[G] <string> specified in 
+**420: Zone <string> specified in 
 interval volumes was not found in the material loading.**
 
-    The zone string specified to contain one
+    The :term:`zone <zones>` string specified to contain one
     of the volumes in the volumes input block
     does not exist.
 
@@ -330,8 +330,8 @@ Input Cross-referencing
 
 **580: Removing mixture <string> not used in any zones.**
 
-    :term:`Mixture` [G] string was
-    defined in the :term:`input file` [G],
+    :term:`Mixture` string was
+    defined in the :term:`input file`,
     but is not used in any zones. It's
     definition is being removed.
 
@@ -341,7 +341,7 @@ each interval.**
 
     The spatial_norm input block must contain
     an entry for each of the :term:`fine mesh
-    intervals` [G]. It is
+    intervals`. It is
     not permissible to have too few.
 
 **621: You have specified too many normalizations. Extra 
@@ -354,10 +354,10 @@ normalizations will be ignored.**
 
 **622: Flux file <string> does not contain enough data.**
 
-    The :term:`flux file <flux>` [G] string
+    The :term:`flux file <flux>` string
     does not contain enough data to provide a
     flux for each of the :term:`fine mesh
-    intervals` [G].
+    intervals`.
 
 .. _Data Library Errors:
 

--- a/doc/usersguide/errortext.rst
+++ b/doc/usersguide/errortext.rst
@@ -19,8 +19,8 @@ Error Message Types
 Example Error Message:
 ======================
 
-| Error name/number:     130: Invalid dimension :doc:`[G] <glossarytext>` type: <string> 
-| Description:           The type of dimension :doc:`[G] <glossarytext>`, string,
+| Error name/number:     130: Invalid :term:`dimension` [G] type: <string> 
+| Description:           The type of :term:`dimension` [G], string,
 		         declared in the dimension block is not supported.
 
 .. _Command-line Parsing:
@@ -35,7 +35,7 @@ Command-line Parsing
 **1: Only one input filename can be specified: <string>.**
 
     There appears to be more than one input filename on the
-    command-line :doc:`[G] <glossarytext>`. This may be 
+    :term:`command-line` [G]. This may be 
     caused by an error in the other command line options,
     or a missing option.
 
@@ -49,7 +49,7 @@ Input Phase
  an error in the input file, ALARA may not immediately
  recognize the error and then report an error during some
  later input block. This is particularly true during the
- first step, reading the input file :doc:`[G] <glossarytext>`
+ first step, reading the :term:`input file` [G]
  itself.
 
 .. _Read Input File:
@@ -60,7 +60,7 @@ Read Input File
 **100: Invalid token in input file: <string>**
 
     There is an error in the input file causing it to read
-    an invalid keyword :doc:`[G] <glossarytext>`.
+    an invalid :term:`keyword` [G].
 
 **101: Unable to open included file: '<string>'.**
 
@@ -79,17 +79,17 @@ Read Input File
 
 **120: Invalid units in cooling time: <time> <units>**
 
-    The specified cooling time :doc:`[G] <glossarytext>` 
+    The specified :term:`cooling time` [G] 
     does not have one of the supported time units.
 
 **121: No after-shutdown/cooling times were defined.**
 
     The cooling input block contains no information before
-    the end keyword :doc:`[G] <glossarytext>`.
+    the end :term:`keyword` [G].
 
 **130: Invalid dimension type: <string>**
 
-    The type of dimension :doc:`[G] <glossarytext>`, string,
+    The type of :term:`dimension` [G], string,
     declared in the dimension block is not supported.
 
 **131: Dimension has no boundaries**
@@ -99,7 +99,7 @@ Read Input File
 
 **140: Invalid flux type: <string>**
 
-    The flux type :doc:`[G] <glossarytext>`, string, specified
+    The :term:`flux type<flux spectra>` [G], string, specified
     in the flux block in not supported.
 
 **150: Invalid geometry type: <string>**
@@ -110,24 +110,24 @@ Read Input File
 **160: History <string> is empty**
 
     The history input block, string, contains no information
-    before the end keyword :doc:`[G] <glossarytext>`.
+    before the end :term:`keyword` [G].
 
 **170: Material Loading is empty.**
 
     The mat_loading input block contains no information
-    before the end keyword :doc:`[G] <glossarytext>`.
+    before the end :term:`keyword` [G].
 
 **180: Target materials for reverse calculations can only be 
 elements or isotopes and not '<string>'**
 
     The constituent type, string, given for this target
     material is not supported. It must be either ''element''
-    or ''isostope :doc:`[G] <glossarytext>`''.
+    or '':term:`isotope` [G]''.
 
 **181: Invalid material constituent: <string>**
 
     The constituent type, string, specified for this
-    mixture :doc:`[G] <glossarytext>` constituent is not
+    :term:`mixture` [G] constituent is not
     supported.
 
 **182: Mixture <string> has no constituents**
@@ -160,9 +160,9 @@ elements or isotopes and not '<string>'**
     The output type, string, specified for this output
     format is not supported.
 
-**240: Unable to open dump file :doc:`[G] <glossarytext>` <string>**
+**240: Unable to open dump file <string>**
 
-    The output ''dump'' file could not be opened.
+    The output :term:`''dump'' file <dump file>` [G] could not be opened.
 
 .. _Input Checking:
 
@@ -218,39 +218,41 @@ volumes for multi-point problems.**
 **330: Duplicate dimensions of type <string>.**
 
     The dimension string was defined more that
-    once in the input file :doc:`[G] <glossarytext>`.
+    once in the :term:`input file` [G].
 
 331: <string1> geometries don't have dimensions of type <string2>.
 
     The dimension type string2 was defined for
     geometry type string1, which does not allow
-    this kind of dimension :doc:`[G] <glossarytext>`.
+    this kind of :term:`dimension` [G].
 
 **340: Unable to open flux file <string1> for flux <string2>.**
 
-    In the flux :doc:`[G] <glossarytext>` definition
+    In the :term:`flux` [G] definition
     string2 the given flux file string1
     cannot be opened.
 
 **350: Toroidal problems with zone dimensions require a major radius.**
 
-    All problems defined as having toroidal
-    geometries :doc:`[G] <glossarytext>` must define
-    a major radius :doc:`[G] <glossarytext>` with
-    the major_radius input block.
+    All problems defined as having :term:`toroidal
+    geometries <major and minor radii of toroidal 
+    geometries>` [G] must define a :term:`major radius <major and 
+    minor radii of toroidal geometries>` 
+    [G] with the major_radius input block.
 
 **351: Toroidal problems with zone dimensions require either
-a minor radius :doc:`[G] <glossarytext>` or a radius dimension.**
+a :term:`minor radius <major and minor radii of toroidal geometries>`
+[G] or a radius dimension.**
 
-    All problems defined as having toroidal
-    geometries :doc:`[G] <glossarytext>` must define
+    All problems defined as having :term:`toroidal
+    geometries <major and minor radii of toroidal geometries>` [G] must define
     a minor radius with either a dimension block
     or the minor_radius input block.
 
 **370: Zone <string1> is loaded with a non-existent 
 mixture: <string2>**
 
-    The mixture :doc:`[G] <glossarytext>` string2
+    The :term:`mixture` [G] string2
     specified to fill zone string1 in the mat_loading
     block is not defined in the input file. Either
     add a new mixture definition or change the name
@@ -306,19 +308,19 @@ item of schedule <string>.**
     The pulsing history string1 required to calculate
     a schedule item of schedule string2 has not been defined.
 
-**420: Zone :doc:`[G] <glossarytext>` <string> specified in 
+**420: :term:`Zone <zones>`[G] <string> specified in 
 interval volumes was not found in the material loading.**
 
     The zone string specified to contain one
     of the volumes in the volumes input block
     does not exist.
 
-**440: ALARA now requires a binary dump file:doc:`[G] glossarytext>`.
+**440: ALARA now requires a binary dump file.
 Openning the default file 'alara.dmp'.**
 
     ALARA uses a binary file to store intermediate
     results. You can set the name of this file
-    using the dump_file input block. Otherwise,
+    using the :term:`dump_file <dump file>` input block. Otherwise,
     the default is used.
 
 .. _Input Cross-referencing:
@@ -328,8 +330,8 @@ Input Cross-referencing
 
 **580: Removing mixture <string> not used in any zones.**
 
-    Mixture :doc:`[G] <glossarytext>` string was
-    defined in the input file :doc:`[G] <glossarytext>`,
+    :term:`Mixture` [G] string was
+    defined in the :term:`input file` [G],
     but is not used in any zones. It's
     definition is being removed.
 
@@ -338,8 +340,8 @@ specifiy any normalizations, you must specify one for
 each interval.**
 
     The spatial_norm input block must contain
-    an entry for each of the fine mesh
-    intervals :doc:`[G] <glossarytext>`. It is
+    an entry for each of the :term:`fine mesh
+    intervals` [G]. It is
     not permissible to have too few.
 
 **621: You have specified too many normalizations. Extra 
@@ -352,10 +354,10 @@ normalizations will be ignored.**
 
 **622: Flux file <string> does not contain enough data.**
 
-    The flux file :doc:`[G] <glossarytext>` string
+    The :term:`flux file <flux>` [G] string
     does not contain enough data to provide a
-    flux for each of the fine mesh
-    intervals :doc:`[G] <glossarytext>`.
+    flux for each of the :term:`fine mesh
+    intervals` [G].
 
 .. _Data Library Errors:
 

--- a/doc/usersguide/glossarytext.rst
+++ b/doc/usersguide/glossarytext.rst
@@ -2,84 +2,48 @@
 Glossary
 ========
 
-alpha particles
+.. glossary::
 
-atomic number
-
-chemical symbol
-
-clearance indices
-
-command-line
-
-constituent
-
-cooling time
-
-cylindrical
-
-data library
-
-dimension
-
-dump file
-
-excited isomeric state
-
-fine mesh intervals'
-
-floating point scalar normalization
-
-flux spectra
-
-gamma emissions
-
-induced activation
-
-input file
-
-irradiation history
-
-isotope
-
-isotopic abundances
-
-isotope's identifier (chemical symbol and mass number)
-
-keyword
-
-major and minor radii of toroidal geometries
-
-mixture
-
-natural abundances
-
-neutrons
-
-neutron irradiation
-
-output files
-
-point
-
-post-processing mode
-
-rectangular
-
-spherical
-
-torus
-
-tree files
-
-truncation
-
-verbosity
-
-waste disposal rating
-
-whitespace
-
-zones
+   alpha particles
+   atomic number
+   chemical symbol
+   clearance indices
+   command-line
+   constituent
+   cooling time
+   cylindrical
+   data library
+   dimension
+   dump file
+   excited isomeric state
+   fine mesh intervals
+   floating point scalar normalization
+   flux
+   flux spectra
+   gamma emissions
+   induced activation
+   input file
+   irradiation history
+   isotope
+   isotopic abundances
+   isotope's identifier (chemical symbol and mass number)
+   keyword
+   major and minor radii of toroidal geometries
+   mixture
+   natural abundances
+   neutrons
+   neutron irradiation
+   output files
+   point
+   post-processing mode
+   rectangular
+   spherical
+   torus
+   tree file
+   truncation
+   verbosity
+   waste disposal rating
+   whitespace
+   zones
 
 

--- a/doc/usersguide/inputtext.rst
+++ b/doc/usersguide/inputtext.rst
@@ -26,7 +26,7 @@ Input File Syntax
 
  In the following list, input blocks indicated in bold
  are required at least once in every :term:`input
- file` [G]:
+ file`:
 
  +-----------------------------+----------------------------+-----------------------------+
  |`Geometry & Materials`_      |`Flux Schedules & Chain -   |`Output & Files`_            |
@@ -55,14 +55,14 @@ Input File Syntax
 **General Input Notes**
 
  1. **Dimension/Volume:** If “[1]” follows an input
-    block name, either the :term:`dimension` [G]
+    block name, either the :term:`dimension`
     or the volume is required, but it will generate an
     error if both are included. 
 
  2. **Input Blocks:** Not all input blocks are required,
     with some being unnecessary for certain problems. Input
     blocks indicated in bold are required at least once in
-    every :term:`input file` [G].
+    every :term:`input file`.
 
     There are also some input blocks which are incompatible
     with each other. While superfluous input blocks may go
@@ -73,11 +73,11 @@ Input File Syntax
     to define their own symbolic names for cross-referencing
     the various input data. Any string of characters can be
     used as long as its does not contain any
-    :term:`whitespace` [G] (spaces, tabs,
+    :term:`whitespace` (spaces, tabs,
     new-lines, etc.).
 
     It is considered dangerous, however, to use a
-    :term:`keyword` [G] as a symbolic name.
+    :term:`keyword` as a symbolic name.
     If the input file is correct, it will function properly,
     but if there are errors in the input file, the usage of
     keywords as symbolic names may make the error message
@@ -117,11 +117,11 @@ Input File Syntax
     non-space character is the pound sign (or number
     sign) (#) are considered as comments. Comments can
     also be used after any single word input (an input
-    value with no :term:`whitespace` [G])
+    value with no :term:`whitespace`)
     by using the same comment character (#). Such
     comments extend to the end of the current line.
     Blank lines are permitted anywhere in the :term:`input
-    file` [G]. 
+    file`. 
 
  8. **Length Units:** Centimeters should be used for all
     length units.
@@ -147,7 +147,7 @@ Geometry
 
 		**Description:** This required input block is
 		only necessary when defining a geometry using 
-		the :term:`dimension` [G] input 
+		the :term:`dimension` input 
 		block, but may always be included. It should 
 		only occur once. 
 
@@ -159,21 +159,21 @@ Geometry
 
 		**Option Description:**
 
-|			:term:`point` [G] --
-|			:term:`rectangular` [G] --
-|			:term:`cylindrical` [G] --
-|			:term:`spherical` [G] --
-|			:term:`torus` [G] --
+|			:term:`point` --
+|			:term:`rectangular` --
+|			:term:`cylindrical` --
+|			:term:`spherical` --
+|			:term:`torus` --
 
 		**Sample Input:** geometry point
 
 		**Notes:** This input block should not be terminated. 
 		If using the dimension input block to define the geometry 
-		and the type is :term:`torus` [G], the 
+		and the type is :term:`torus`, the 
 		:term:`major_radius <major and minor radii of toroidal
-		geometries>` [G] input block is 
+		geometries>` input block is 
 		required and the :term:`minor_radius <major and minor 
-		radii of toroidal geometries>` [G] block may also 
+		radii of toroidal geometries>` block may also 
 		be required. 
 
 ------------------
@@ -187,7 +187,7 @@ Dimension
 
 		**Description:** This input block is used to define the 
 		geometry layout, and should be included once for each 
-		:term:`dimension` [G] needed in the problem. 
+		:term:`dimension` needed in the problem. 
 
 		**Syntax:** 
 		::
@@ -202,7 +202,7 @@ Dimension
 			end
 
 		**Option Description:** The dimension block's first element 
-		indicates which :term:`dimension` [G] is being 
+		indicates which :term:`dimension` is being 
 		defined and should be one of the following: 
 
 			x --
@@ -214,7 +214,7 @@ Dimension
 
 		**Sample Input:** The dimension block's next element is the 
 		first zone's lower boundary, expressed as a :term:`floating point 
-		number <floating point scalar normalization>` [G]. 
+		number <floating point scalar normalization>`. 
 		This is followed by a list of pairs, one pair for 
 		each zone: an integer specifying the number of 
 		intervals in this zone in this dimension and a 
@@ -230,9 +230,9 @@ Dimension
 
 		**Notes:** ALARA will check to ensure that only dimensions 
 		relevant to the defined geometry are included. For example, 
-		defining the 'x' dimension in a spherical :doc:`[G] <glossarytext>`
+		defining the 'x' dimension in a :term:`spherical`
 		problem will generate an error. Since this method of defining 
-		the geometry calculates the fine mesh intervals' :doc:`[G] <glossarytext>`
+		the geometry calculates the :term:`fine mesh intervals`
 		zone membership and volume from the dimension data, it is 
 		incompatible with the volumes input block. Including 
 		both will generate an error message.
@@ -250,8 +250,8 @@ Major Radius and Minor Radius
 
 		**Description:** These two input blocks are used to define 
 		the :term:`major and minor radii of toroidal 
-		geometries` [G]. They are only needed in defining a 
-		:term:`toroidal <torus>` [G] geometry with dimension 
+		geometries`. They are only needed in defining a 
+		:term:`toroidal <torus>` geometry with dimension 
 		input blocks, and each should only be included once. 
 		Furthermore, if the minor radius dimension is defined with 
 		a dimension block, the minor_radius input block is not 
@@ -281,7 +281,7 @@ Volumes
 		(required [1] once) 
 
 		**Description:** This input block is used to define the 
-		:term:`fine mesh intervals` [G] volumes 
+		:term:`fine mesh intervals` volumes 
 		and zone membership. 
 
 		**Syntax:**
@@ -296,13 +296,13 @@ Volumes
 
 		This input block should be a list of pairs, one pair 
 		for each interval. Each pair consists of a :term:`floating 
-		point value <floating point scalar normalization>` [G] for the volume 
+		point value <floating point scalar normalization>` for the volume 
 		of that interval and the symbolic name of the zone 
 		containing that interval. These symbolic names 
 		should correspond with the symbolic names given 
 		to the zones in the mat_loading input block. This 
 		list must be terminated with the 
-		:term:`keyword` [G] end. 
+		:term:`keyword` end. 
 
 		**Sample Input:**
 		::
@@ -330,11 +330,11 @@ mat_loading
 
 		**Description:** This input block is used to 
 		indicate which mixtures are contained in each 
-		:term:`zone <zones>` [G]. This block is 
+		:term:`zone <zones>`. This block is 
 		a list with one pair of entries for every zone. 
 		Each pair consists of a symbolic name for the 
 		zone and a symbolic name for the :term:`mixture` 
-		[G] contained in that 
+		contained in that 
 		zone. This list is terminated by the keyword 
 		end. This block should only occur once. 
 		Multiple occurrences will result in undefined 
@@ -360,7 +360,7 @@ mat_loading
 
 		**Notes:** If the geometry is defined using the 
 		dimension input blocks, the number of :term:`zones` 
-		[G] defined here must match 
+		defined here must match 
 		the number of zones defined in the dimension 
 		blocks exactly; if not, an error results. If 
 		the volumes method is used to define the geometry, 
@@ -422,7 +422,7 @@ Mixture
 			density of this material, based on the density 
 			given in the material library. The final 
 			element is a :term:`floating point <floating 
-			point scalar normalization>` [G]
+			point scalar normalization>`
 			value representing the volume fraction of 
 			this material in this mixture. Both of the 
 			last two values are typically between 0 and 1.
@@ -441,17 +441,17 @@ Mixture
 
 			This entry has three additional elements. The 
 			second element in this entry is the element's 
-			modified :term:`chemical symbol` [G]. 
+			modified :term:`chemical symbol`. 
 			This element will be expanded into a list of 
-			:term:`isotopes <isotope>` [G] using the 
+			:term:`isotopes <isotope>` using the 
 			abundances found in the element library for 
 			that modified chemcial symbol. A modified 
-			:term:`chemical symbol` [G] has 
+			:term:`chemical symbol` has 
 			the format ''ZZ:XXXXXX...'', where ZZ is the 
 			standard chemical symbol, and the string
 			XXXXXX... allows for :term:`isotopic 
-			abundances` [G] different 
-			from :term:`natural abundances` [G].
+			abundances` different 
+			from :term:`natural abundances`.
 
 		The final two elements of this section are identical to 
 		the final two elements of the material type entry, 
@@ -462,7 +462,7 @@ Mixture
 			This type of entry has two additional elements 
 			and is provided as a convenience and indicates 
 			that this constituent is like another user-defined 
-			:term:`mixture` [G], with a 
+			:term:`mixture`, with a 
 			potentially different density. The second element 
 			of this entry is the symbolic name of another 
 			mixture definition. If the other mixture 
@@ -479,7 +479,7 @@ Mixture
 
 			This type of entry is used to initiate a reverse 
 			calculation (see the ALARA Technical Manual) 
-			and define the target :term:`isotopes <isotope>` [G]
+			and define the target :term:`isotopes <isotope>`
 			for the reverse calculation. The user can 
 			define an arbitrary number of target isotopes. 
 			The second element of this entry is one of the 
@@ -487,7 +487,7 @@ Mixture
 			of target this is. The final element is the symbolic 
 			name of either the element or isotope. For isotopes, 
 			the symbolic name is in the format ZZ-AAA, where ZZ 
-			is the :term:`chemical symbol` [G] and 
+			is the :term:`chemical symbol` and 
 			AAA is the mass number. There are no elements 
 			representing relative densities or volume fractions. 
 			If a target is of type element, the element will be 
@@ -552,7 +552,7 @@ skip_zones
 		the user to limit which zones are being solved in 
 		a given calculation (see solve_zones). It is 
 		common for a user to create a single complete 
-		:term:`input file` [G] describing 
+		:term:`input file` describing 
 		the entire geometry/composition, and want to 
 		exclude certain parts of the geometry/composition 
 		for particular cases. 
@@ -595,15 +595,15 @@ Flux
 		(required: once per defined flux) 
 
 		**Description:** This input block defines a set 
-		of :term:`flux spectra` [G]. 
+		of :term:`flux spectra`. 
 
 		**Syntax:**
 
 		The first element of this block is a symbolic name, 
 		used to refer to this flux spectra definition. The 
 		other elements of this block are a filename, a 
-		:term:`floating point scalar normalization` 
-		[G], an integer skip value 
+		:term:`floating point scalar normalization`, 
+		an integer skip value 
 		(see below), and flux type indicator string, 
 		respectively. 
 
@@ -612,7 +612,7 @@ Flux
 		appropriate to find the file from the directory in 
 		which ALARA will be run. The flux file itself 
 		contains a simple list of group fluxes for each of 
-		the :term:`fine mesh intervals` [G] 
+		the :term:`fine mesh intervals` 
 		defined in the problem. The number of groups for 
 		each interval and the order of those groups is 
 		determined entirely by the data library being used. 
@@ -654,7 +654,7 @@ Flux
 		**Notes:**
 
 		Since different parts of the :term:`irradiation 
-		history` [G] can have different 
+		history` can have different 
 		flux spectra, this block may occur as many times as 
 		necessary to represent all the different necessary 
 		flux definitions. 
@@ -670,7 +670,7 @@ spatial_norm
 
 		**Description:** This input block allows the user 
 		to specify a scalar flux normalization for each :term:`fine 
-		mesh interval <fine mesh intervals>` [G], such as 
+		mesh interval <fine mesh intervals>`, such as 
 		might be required to re-normalize the results of 
 		a transport calculation on an approximated geometry.
 
@@ -796,7 +796,7 @@ Truncation
 
 		**Description:** This fixed sized input block 
 		defines the primary parameter used in 
-		:term:`truncating <truncation>` [G] the activation 
+		:term:`truncating <truncation>` the activation 
 		trees. See the ALARA Technical Manual for a 
 		detailed discussion of the tree truncation issue.
 
@@ -806,7 +806,7 @@ Truncation
 			truncation <tol_value>
 
 		The only element of this block is the :term:`truncation` 
-		[G] tolerance. 
+		tolerance. 
 
 		**Sample Input:**
 		::
@@ -832,7 +832,7 @@ Impurity
 
 		**Description:** This fixed sized input block 
 		defines the parameters used to treat initial 
-		:term:`isotopes <isotope>` [G] as impurities. 
+		:term:`isotopes <isotope>` as impurities. 
 		This feature allows the user to build shorter 
 		chains for impurities, since their contributions 
 		tend to be less significant. This can make 
@@ -950,7 +950,7 @@ ref_flux_type
 
 		In both cases, the comparison/averaging takes place 
 		over all the intervals which contain a given root 
-		:term:`isotope` [G], not just over 
+		:term:`isotope`, not just over 
 		a single zone, component, or material loading. 
 
 --------------------------------------
@@ -969,7 +969,7 @@ Cooling
 		(optional once) 
 
 		**Description:** This input block is used to define the 
-		after-shutdown :term:`cooling times <cooling time>` [G] 
+		after-shutdown :term:`cooling times <cooling time>` 
 		at which the problem will be solved. 
 
 		**Syntax:**
@@ -987,7 +987,7 @@ Cooling
 		This block is simply a list of times, where each time 
 		consists of a floating point time followed by a single 
 		character defining the time's units. Since an arbitrary 
-		number of :terms:cooling times` [G] can 
+		number of :terms:cooling times` can 
 		be solved, this list must be terminated with the 
 		keyword 'end'. 
 
@@ -1112,7 +1112,7 @@ Output
 
 		The wdr output modifier requires an additional text 
 		string parameter representing the filename to use for 
-		calculating the :term:`waste disposal rating` [G]
+		calculating the :term:`waste disposal rating`
 		or clearance limits. A detailed description of the WDR 
 		file is available here. To calculate the WDR based on 
 		different standards, simply repeat this modifier within 

--- a/doc/usersguide/inputtext.rst
+++ b/doc/usersguide/inputtext.rst
@@ -25,8 +25,8 @@ Input File Syntax
  sample input file.
 
  In the following list, input blocks indicated in bold
- are required at least once in every input
- file :doc:`[G] <glossarytext>`:
+ are required at least once in every :term:`input
+ file` [G]:
 
  +-----------------------------+----------------------------+-----------------------------+
  |`Geometry & Materials`_      |`Flux Schedules & Chain -   |`Output & Files`_            |
@@ -55,14 +55,14 @@ Input File Syntax
 **General Input Notes**
 
  1. **Dimension/Volume:** If “[1]” follows an input
-    block name, either the dimension :doc:`[G] <glossarytext>`
+    block name, either the :term:`dimension` [G]
     or the volume is required, but it will generate an
     error if both are included. 
 
  2. **Input Blocks:** Not all input blocks are required,
     with some being unnecessary for certain problems. Input
     blocks indicated in bold are required at least once in
-    every input file :doc:`[G] <glossarytext>`.
+    every :term:`input file` [G].
 
     There are also some input blocks which are incompatible
     with each other. While superfluous input blocks may go
@@ -73,11 +73,11 @@ Input File Syntax
     to define their own symbolic names for cross-referencing
     the various input data. Any string of characters can be
     used as long as its does not contain any
-    whitespace :doc:`[G] <glossarytext>` (spaces, tabs,
+    :term:`whitespace` [G] (spaces, tabs,
     new-lines, etc.).
 
     It is considered dangerous, however, to use a
-    keyword :doc:`[G] <glossarytext>` as a symbolic name.
+    :term:`keyword` [G] as a symbolic name.
     If the input file is correct, it will function properly,
     but if there are errors in the input file, the usage of
     keywords as symbolic names may make the error message
@@ -117,11 +117,11 @@ Input File Syntax
     non-space character is the pound sign (or number
     sign) (#) are considered as comments. Comments can
     also be used after any single word input (an input
-    value with no whitespace :doc:`[G] <glossarytext>`)
+    value with no :term:`whitespace` [G])
     by using the same comment character (#). Such
     comments extend to the end of the current line.
-    Blank lines are permitted anywhere in the input
-    file :doc:`[G] <glossarytext>`. 
+    Blank lines are permitted anywhere in the :term:`input
+    file` [G]. 
 
  8. **Length Units:** Centimeters should be used for all
     length units.
@@ -147,7 +147,7 @@ Geometry
 
 		**Description:** This required input block is
 		only necessary when defining a geometry using 
-		the dimension :doc:`[G] <glossarytext>` input 
+		the :term:`dimension` [G] input 
 		block, but may always be included. It should 
 		only occur once. 
 
@@ -159,20 +159,22 @@ Geometry
 
 		**Option Description:**
 
-|			point :doc:`[G] <glossarytext>` --
-|			rectangular :doc:`[G] <glossarytext>` --
-|			cylindrical :doc:`[G] <glossarytext>` --
-|			spherical :doc:`[G] <glossarytext>` --
-|			torus :doc:`[G] <glossarytext>` --
+|			:term:`point` [G] --
+|			:term:`rectangular` [G] --
+|			:term:`cylindrical` [G] --
+|			:term:`spherical` [G] --
+|			:term:`torus` [G] --
 
 		**Sample Input:** geometry point
 
 		**Notes:** This input block should not be terminated. 
 		If using the dimension input block to define the geometry 
-		and the type is torus :doc:`[G] <glossarytext>` , the 
-		major_radius :doc:`[G] <glossarytext>` input block is 
-		required and the minor_radius :doc:`[G] <glossarytext>`
-		block may also be required. 
+		and the type is :term:`torus` [G], the 
+		:term:`major_radius <major and minor radii of toroidal
+		geometries>` [G] input block is 
+		required and the :term:`minor_radius <major and minor 
+		radii of toroidal geometries>` [G] block may also 
+		be required. 
 
 ------------------
 
@@ -185,7 +187,7 @@ Dimension
 
 		**Description:** This input block is used to define the 
 		geometry layout, and should be included once for each 
-		dimension :doc:`[G] <glossarytext>` needed in the problem. 
+		:term:`dimension` [G] needed in the problem. 
 
 		**Syntax:** 
 		::
@@ -200,7 +202,7 @@ Dimension
 			end
 
 		**Option Description:** The dimension block's first element 
-		indicates which dimension :doc:`[G] <glossarytext>` is being 
+		indicates which :term:`dimension` [G] is being 
 		defined and should be one of the following: 
 
 			x --
@@ -211,10 +213,11 @@ Dimension
 			phi --
 
 		**Sample Input:** The dimension block's next element is the 
-		first zone's lower boundary, expressed as a floating point 
-		number :doc:`[G] <glossarytext>`. This is followed by a list 
-		of pairs, one pair for each zone: an integer specifying the 
-		number of intervals in this zone in this dimension and a 
+		first zone's lower boundary, expressed as a :term:`floating point 
+		number <floating point scalar normalization>` [G]. 
+		This is followed by a list of pairs, one pair for 
+		each zone: an integer specifying the number of 
+		intervals in this zone in this dimension and a 
 		floating point number indicating the zone's upper boundary. 
 		This list is terminated with the end keyword. 
 		::
@@ -246,9 +249,9 @@ Major Radius and Minor Radius
 		(required once [each] for geometry torus) 
 
 		**Description:** These two input blocks are used to define 
-		the major and minor radii :doc:`[G] <glossarytext>` of toroidal 
-		geometries. They are only needed in defining a 
-		toroidal :doc:`[G] <glossarytext>` geometry with dimension 
+		the :term:`major and minor radii of toroidal 
+		geometries` [G]. They are only needed in defining a 
+		:term:`toroidal <torus>` [G] geometry with dimension 
 		input blocks, and each should only be included once. 
 		Furthermore, if the minor radius dimension is defined with 
 		a dimension block, the minor_radius input block is not 
@@ -278,7 +281,7 @@ Volumes
 		(required [1] once) 
 
 		**Description:** This input block is used to define the 
-		fine mesh intervals' :doc:`[G] <glossarytext>` volumes 
+		:term:`fine mesh intervals` [G] volumes 
 		and zone membership. 
 
 		**Syntax:**
@@ -292,14 +295,14 @@ Volumes
 			end
 
 		This input block should be a list of pairs, one pair 
-		for each interval. Each pair consists of a floating 
-		point :doc:`[G] <glossarytext>` value for the volume 
+		for each interval. Each pair consists of a :term:`floating 
+		point value <floating point scalar normalization>` [G] for the volume 
 		of that interval and the symbolic name of the zone 
 		containing that interval. These symbolic names 
 		should correspond with the symbolic names given 
 		to the zones in the mat_loading input block. This 
 		list must be terminated with the 
-		keyword :doc:`[G] <glossarytext>` end. 
+		:term:`keyword` [G] end. 
 
 		**Sample Input:**
 		::
@@ -327,11 +330,11 @@ mat_loading
 
 		**Description:** This input block is used to 
 		indicate which mixtures are contained in each 
-		zone :doc:`[G] <glossarytext>`. This block is 
+		:term:`zone <zones>` [G]. This block is 
 		a list with one pair of entries for every zone. 
 		Each pair consists of a symbolic name for the 
-		zone and a symbolic name for the mixture 
-		:doc:`[G] <glossarytext>` contained in that 
+		zone and a symbolic name for the :term:`mixture` 
+		[G] contained in that 
 		zone. This list is terminated by the keyword 
 		end. This block should only occur once. 
 		Multiple occurrences will result in undefined 
@@ -356,8 +359,8 @@ mat_loading
 			end
 
 		**Notes:** If the geometry is defined using the 
-		dimension input blocks, the number of zones 
-		:doc:`[G] <glossarytext>` defined here must match 
+		dimension input blocks, the number of :term:`zones` 
+		[G] defined here must match 
 		the number of zones defined in the dimension 
 		blocks exactly; if not, an error results. If 
 		the volumes method is used to define the geometry, 
@@ -418,7 +421,8 @@ Mixture
 			floating point value representing the relative 
 			density of this material, based on the density 
 			given in the material library. The final 
-			element is a floating point :doc:`[G] <glossarytext>`
+			element is a :term:`floating point <floating 
+			point scalar normalization>` [G]
 			value representing the volume fraction of 
 			this material in this mixture. Both of the 
 			last two values are typically between 0 and 1.
@@ -437,17 +441,17 @@ Mixture
 
 			This entry has three additional elements. The 
 			second element in this entry is the element's 
-			modified chemical symbol :doc:`[G] <glossarytext>`. 
+			modified :term:`chemical symbol` [G]. 
 			This element will be expanded into a list of 
-			isotopes :doc:`[G] <glossarytext>` using the 
+			:term:`isotopes <isotope>` [G] using the 
 			abundances found in the element library for 
 			that modified chemcial symbol. A modified 
-			chemical symbol :doc:`[G] <glossarytext>` has 
+			:term:`chemical symbol` [G] has 
 			the format ''ZZ:XXXXXX...'', where ZZ is the 
 			standard chemical symbol, and the string
-			XXXXXX... allows for isotopic 
-			abundances :doc:`[G] <glossarytext>` different 
-			from natural abundances :doc:`[G] <glossarytext>`.
+			XXXXXX... allows for :term:`isotopic 
+			abundances` [G] different 
+			from :term:`natural abundances` [G].
 
 		The final two elements of this section are identical to 
 		the final two elements of the material type entry, 
@@ -458,7 +462,7 @@ Mixture
 			This type of entry has two additional elements 
 			and is provided as a convenience and indicates 
 			that this constituent is like another user-defined 
-			mixture :doc:`[G] <glossarytext>`, with a 
+			:term:`mixture` [G], with a 
 			potentially different density. The second element 
 			of this entry is the symbolic name of another 
 			mixture definition. If the other mixture 
@@ -475,7 +479,7 @@ Mixture
 
 			This type of entry is used to initiate a reverse 
 			calculation (see the ALARA Technical Manual) 
-			and define the target isotopes :doc:`[G] <glossarytext>`
+			and define the target :term:`isotopes <isotope>` [G]
 			for the reverse calculation. The user can 
 			define an arbitrary number of target isotopes. 
 			The second element of this entry is one of the 
@@ -483,7 +487,7 @@ Mixture
 			of target this is. The final element is the symbolic 
 			name of either the element or isotope. For isotopes, 
 			the symbolic name is in the format ZZ-AAA, where ZZ 
-			is the chemical symbol :doc:`[G] <glossarytext>` and 
+			is the :term:`chemical symbol` [G] and 
 			AAA is the mass number. There are no elements 
 			representing relative densities or volume fractions. 
 			If a target is of type element, the element will be 
@@ -548,7 +552,7 @@ skip_zones
 		the user to limit which zones are being solved in 
 		a given calculation (see solve_zones). It is 
 		common for a user to create a single complete 
-		input file :doc:`[G] <glossarytext>` describing 
+		:term:`input file` [G] describing 
 		the entire geometry/composition, and want to 
 		exclude certain parts of the geometry/composition 
 		for particular cases. 
@@ -591,15 +595,15 @@ Flux
 		(required: once per defined flux) 
 
 		**Description:** This input block defines a set 
-		of flux spectra :doc:`[G] <glossarytext>`. 
+		of :term:`flux spectra` [G]. 
 
 		**Syntax:**
 
 		The first element of this block is a symbolic name, 
 		used to refer to this flux spectra definition. The 
 		other elements of this block are a filename, a 
-		floating point scalar normalization 
-		:doc:`[G] <glossarytext>`, an integer skip value 
+		:term:`floating point scalar normalization` 
+		[G], an integer skip value 
 		(see below), and flux type indicator string, 
 		respectively. 
 
@@ -608,7 +612,7 @@ Flux
 		appropriate to find the file from the directory in 
 		which ALARA will be run. The flux file itself 
 		contains a simple list of group fluxes for each of 
-		the fine mesh intervals :doc:`[G] <glossarytext>` 
+		the :term:`fine mesh intervals` [G] 
 		defined in the problem. The number of groups for 
 		each interval and the order of those groups is 
 		determined entirely by the data library being used. 
@@ -649,8 +653,8 @@ Flux
 
 		**Notes:**
 
-		Since different parts of the irradiation 
-		history :doc:`[G] <glossarytext>` can have different 
+		Since different parts of the :term:`irradiation 
+		history` [G] can have different 
 		flux spectra, this block may occur as many times as 
 		necessary to represent all the different necessary 
 		flux definitions. 
@@ -665,8 +669,8 @@ spatial_norm
 		(optional once) 
 
 		**Description:** This input block allows the user 
-		to specify a scalar flux normalization for each fine 
-		mesh interval :doc:`[G] <glossarytext>`, such as 
+		to specify a scalar flux normalization for each :term:`fine 
+		mesh interval <fine mesh intervals>` [G], such as 
 		might be required to re-normalize the results of 
 		a transport calculation on an approximated geometry.
 
@@ -792,7 +796,7 @@ Truncation
 
 		**Description:** This fixed sized input block 
 		defines the primary parameter used in 
-		truncating :doc:`[G] <glossarytext>` the activation 
+		:term:`truncating <truncation>` [G] the activation 
 		trees. See the ALARA Technical Manual for a 
 		detailed discussion of the tree truncation issue.
 
@@ -801,8 +805,8 @@ Truncation
 
 			truncation <tol_value>
 
-		The only element of this block is the truncation 
-		:doc:`[G] <glossarytext>` tolerance. 
+		The only element of this block is the :term:`truncation` 
+		[G] tolerance. 
 
 		**Sample Input:**
 		::
@@ -828,7 +832,7 @@ Impurity
 
 		**Description:** This fixed sized input block 
 		defines the parameters used to treat initial 
-		isotopes :doc:`[G] <glossarytext>` as impurities. 
+		:term:`isotopes <isotope>` [G] as impurities. 
 		This feature allows the user to build shorter 
 		chains for impurities, since their contributions 
 		tend to be less significant. This can make 
@@ -946,7 +950,7 @@ ref_flux_type
 
 		In both cases, the comparison/averaging takes place 
 		over all the intervals which contain a given root 
-		isotope :doc:`[G] <glossarytext>`, not just over 
+		:term:`isotope` [G], not just over 
 		a single zone, component, or material loading. 
 
 --------------------------------------
@@ -965,7 +969,7 @@ Cooling
 		(optional once) 
 
 		**Description:** This input block is used to define the 
-		after-shutdown cooling times :doc:`[G] <glossarytext>` 
+		after-shutdown :term:`cooling times <cooling time>` [G] 
 		at which the problem will be solved. 
 
 		**Syntax:**
@@ -983,7 +987,7 @@ Cooling
 		This block is simply a list of times, where each time 
 		consists of a floating point time followed by a single 
 		character defining the time's units. Since an arbitrary 
-		number of cooling times :doc:`[G] <glossarytext>` can 
+		number of :terms:cooling times` [G] can 
 		be solved, this list must be terminated with the 
 		keyword 'end'. 
 
@@ -1108,7 +1112,7 @@ Output
 
 		The wdr output modifier requires an additional text 
 		string parameter representing the filename to use for 
-		calculating the waste disposal rating :doc:`[G] <glossarytext>`
+		calculating the :term:`waste disposal rating` [G]
 		or clearance limits. A detailed description of the WDR 
 		file is available here. To calculate the WDR based on 
 		different standards, simply repeat this modifier within 

--- a/doc/usersguide/introtext.rst
+++ b/doc/usersguide/introtext.rst
@@ -2,21 +2,21 @@
 INTRODUCTION
 ============
 
- The primary purpose of ALARA is to calculate the induced
- activation :doc:`[G] <glossarytext>` caused by neutron
- irradiation :doc:`[G] <glossarytext>` throughout a nuclear
+ The primary purpose of ALARA is to calculate the :term:`induced
+ activation` [G] caused by :term:`neutron
+ irradiation` [G] throughout a nuclear
  system (including fission reactors, fusion reactors,
  and accelerators). The usage of ALARA is fairly straightforward,
  requiring little knowledge of the code's inner workings.
  This Users' Guide, however does assume that the reader is
- familiar with the basic problem of induced activation
- :doc:`[G] <glossarytext>`. Background on induced activation, and
+ familiar with the basic problem of :term:`induced activation`
+ [G]. Background on induced activation, and
  details on ALARA's can be found in [ref. 1]. This reference
  will also help ensure that ALARA is well-suited to the
  problems that you are trying to solve.
 
  This Users' Guide will describe the command-line options of
- ALARA, input file :doc:`[G] <glossarytext>` structure
+ ALARA, :term:`input file` [G] structure
  and the basic support files necessary to run ALARA.
 
 FEATURES
@@ -40,8 +40,8 @@ FEATURES
   
    * multi-point (3-D) solutions in a variety of geometries
    * accurate solution of loops in activation trees
-   * exact modeling of multi-level pulsing irradiation
-     histories :doc:`[G] <glossarytext>`
+   * exact modeling of multi-level pulsing :term:`irradiation
+     histories <irradiation history>` [G]
    * user-defined calculation precision/accuracy
    * tracking the accumulation of light ions     
 
@@ -53,8 +53,8 @@ FEATURES
    * full, easy-to-read activation tree output (not just
      pathway analysis)
    * flexible output options NOW including the direct
-     calculation of waste disposal rating :doc:`[G] <glossarytext>`
-     and clearance indices :doc:`[G] <glossarytext>`. 
+     calculation of :term:`waste disposal rating` [G]
+     and :term:`clearance indices` [G]. 
 
  The following ADVANCED features are unique to ALARA
  and its development history: 

--- a/doc/usersguide/introtext.rst
+++ b/doc/usersguide/introtext.rst
@@ -3,20 +3,20 @@ INTRODUCTION
 ============
 
  The primary purpose of ALARA is to calculate the :term:`induced
- activation` [G] caused by :term:`neutron
- irradiation` [G] throughout a nuclear
+ activation` caused by :term:`neutron
+ irradiation` throughout a nuclear
  system (including fission reactors, fusion reactors,
  and accelerators). The usage of ALARA is fairly straightforward,
  requiring little knowledge of the code's inner workings.
  This Users' Guide, however does assume that the reader is
- familiar with the basic problem of :term:`induced activation`
- [G]. Background on induced activation, and
+ familiar with the basic problem of :term:`induced activation`.
+ Background on induced activation, and
  details on ALARA's can be found in [ref. 1]. This reference
  will also help ensure that ALARA is well-suited to the
  problems that you are trying to solve.
 
  This Users' Guide will describe the command-line options of
- ALARA, :term:`input file` [G] structure
+ ALARA, :term:`input file` structure
  and the basic support files necessary to run ALARA.
 
 FEATURES
@@ -41,7 +41,7 @@ FEATURES
    * multi-point (3-D) solutions in a variety of geometries
    * accurate solution of loops in activation trees
    * exact modeling of multi-level pulsing :term:`irradiation
-     histories <irradiation history>` [G]
+     histories <irradiation history>`
    * user-defined calculation precision/accuracy
    * tracking the accumulation of light ions     
 
@@ -53,8 +53,8 @@ FEATURES
    * full, easy-to-read activation tree output (not just
      pathway analysis)
    * flexible output options NOW including the direct
-     calculation of :term:`waste disposal rating` [G]
-     and :term:`clearance indices` [G]. 
+     calculation of :term:`waste disposal rating`
+     and :term:`clearance indices`. 
 
  The following ADVANCED features are unique to ALARA
  and its development history: 

--- a/doc/usersguide/outputtext.rst
+++ b/doc/usersguide/outputtext.rst
@@ -19,7 +19,7 @@ Format
 ======
 
  As described in the section on :doc:`command-line <commandtext>`
- :doc:`[G] <glossarytext>` arguments, various levels of output
+ arguments, various levels of output
  are available during the calculation. The first part of the output
  file will contain this verbose output, including confirmation
  of the input data and details of the cross-referencing and
@@ -28,12 +28,11 @@ Format
  The second part of the output file shows details on the tree building
  process, ranging from a simple list of the root isotopes being solved
  and statistics on the size and speed of the solution, to details on
- the chain growth and truncation :doc:`[G] <glossarytext>`
- calculations (depending on the verbosity :doc:`[G] <glossarytext>`
- specified on the
- :doc:`command-line <commandtext>`:doc:`[G] <glossarytext>`). 
+ the chain growth and :term:`truncation` [G]
+ calculations (depending on the :term:`verbosity` [G] specified on the
+ :doc:`command-line <commandtext>`). 
 
- The final part of the output file :doc:`[G] <glossarytext>`
+ The final part of the :term:`output files` [G]
  are the results, as requested by the user in the input file. This
  output will include one section for each output format description
  given by the user. Each of these sections will be divided into
@@ -67,12 +66,12 @@ Format
 Table Type 1
 ============
 
-	The first type has a row for each isotope :doc:`[G] <glossarytext>`
+	The first type has a row for each :term:`isotope` [G] 
 	produced in the problem that has a non-zero response. If 
-	the constituent keyword :doc:`[G] <glossarytext>` is 
+	the constituent :term:`keyword` [G] is 
 	given in the output block, there will be one table for 
 	each constituent, followed by a table for the total 
-	mixture :doc:`[G] <glossarytext>`. 
+	:term:`mixture` [G]. 
 
 	For the isotopic results of individual mixture constituents, 
 	all the values are normalized to the volume fraction of that 
@@ -82,7 +81,7 @@ Table Type 1
 	per unit volume (or mass) containing only that constituent. 
 
 	For most results, the table containing the total isotopic 
-	results for the interval, zone :doc:`[G] <glossarytext>`, 
+	results for the interval, :term:`zone <zones>` [G], 
 	or mixture, is not normalized, and these values represent 
 	the result for the mixture as described in the input, 
 	regardless of what volume fraction if filled. However, 
@@ -117,8 +116,8 @@ Tree File
 Description
 ===========
 
- ALARA also optionally produces a so-called tree
- file :doc:`[G] <glossarytext>` to allow some rudimentary
+ ALARA also optionally produces a so-called :term:`tree
+ file` [G] to allow some rudimentary
  pathway analysis. The tree file contains much information about
  the creation and truncation of the trees and chains used to
  calculate the transmutation and activation in the problem.
@@ -226,7 +225,7 @@ Format
 ======
 
  For each spatial region, there is a section for each isotope
- responsible for gamma emissions :doc:`[G] <glossarytext>` and a
+ responsible for :term:`gamma emissions` [G] and a
  section for the total gamma emissions. Each of these sections has
  a header line consisting of the isotope's identifier (chemical
  symbol and mass number) or the keyword "TOTAL", respectively.

--- a/doc/usersguide/outputtext.rst
+++ b/doc/usersguide/outputtext.rst
@@ -28,11 +28,11 @@ Format
  The second part of the output file shows details on the tree building
  process, ranging from a simple list of the root isotopes being solved
  and statistics on the size and speed of the solution, to details on
- the chain growth and :term:`truncation` [G]
- calculations (depending on the :term:`verbosity` [G] specified on the
+ the chain growth and :term:`truncation`
+ calculations (depending on the :term:`verbosity` specified on the
  :doc:`command-line <commandtext>`). 
 
- The final part of the :term:`output files` [G]
+ The final part of the :term:`output files`
  are the results, as requested by the user in the input file. This
  output will include one section for each output format description
  given by the user. Each of these sections will be divided into
@@ -66,12 +66,12 @@ Format
 Table Type 1
 ============
 
-	The first type has a row for each :term:`isotope` [G] 
+	The first type has a row for each :term:`isotope` 
 	produced in the problem that has a non-zero response. If 
-	the constituent :term:`keyword` [G] is 
+	the constituent :term:`keyword` is 
 	given in the output block, there will be one table for 
 	each constituent, followed by a table for the total 
-	:term:`mixture` [G]. 
+	:term:`mixture`. 
 
 	For the isotopic results of individual mixture constituents, 
 	all the values are normalized to the volume fraction of that 
@@ -81,7 +81,7 @@ Table Type 1
 	per unit volume (or mass) containing only that constituent. 
 
 	For most results, the table containing the total isotopic 
-	results for the interval, :term:`zone <zones>` [G], 
+	results for the interval, :term:`zone <zones>`, 
 	or mixture, is not normalized, and these values represent 
 	the result for the mixture as described in the input, 
 	regardless of what volume fraction if filled. However, 
@@ -117,7 +117,7 @@ Description
 ===========
 
  ALARA also optionally produces a so-called :term:`tree
- file` [G] to allow some rudimentary
+ file` to allow some rudimentary
  pathway analysis. The tree file contains much information about
  the creation and truncation of the trees and chains used to
  calculate the transmutation and activation in the problem.
@@ -225,7 +225,7 @@ Format
 ======
 
  For each spatial region, there is a section for each isotope
- responsible for :term:`gamma emissions` [G] and a
+ responsible for :term:`gamma emissions` and a
  section for the total gamma emissions. Each of these sections has
  a header line consisting of the isotope's identifier (chemical
  symbol and mass number) or the keyword "TOTAL", respectively.

--- a/doc/usersguide/support.rst
+++ b/doc/usersguide/support.rst
@@ -25,7 +25,7 @@ Description
 ===========
 
  The element library allows the user to define the
- :term:`isotopic abundances` [G]
+ :term:`isotopic abundances`
  to be used for each element. While this library
  should normally include a  definition of the natural
  abundances for each element, an extension is available
@@ -41,10 +41,10 @@ Format
  following five entries: 
 
    * a string indicating the name/identifier,
-   * a :term:`floating point value <floating point scalar normalization>` [G] for the molar mass,
-   * an integer value for the :term:`atomic number` [G],
+   * a :term:`floating point value <floating point scalar normalization>` for the molar mass,
+   * an integer value for the :term:`atomic number`,
    * a floating point value for the theoretical density, and
-   * an integer value defining the number of :term:`isotopes <isotope>` [G].
+   * an integer value defining the number of :term:`isotopes <isotope>`.
 
  This is followed by two entries for each of these isotopes: 
 
@@ -58,15 +58,15 @@ Naming Elemental Definitions
 ============================
 
  The names/identifiers for all elemental definitions must
- be derived from the :term:`chemical symbol` [G]
+ be derived from the :term:`chemical symbol`
  for that element, using the format ZZ[:AAA...], where ZZ
- represents the :term:`chemical symbol` [G],
+ represents the :term:`chemical symbol`,
  and [:AAA...] represents an optional modifier, separated by a
  colon, ':', from the chemical symbol. By  convention, entries
  without modifiers are used to define the :term:`natural
- abundances` [G] of isotopes. The
+ abundances` of isotopes. The
  modifier must be a character string containing no
- :term:`whitespace` [G]. [example: a
+ :term:`whitespace`. [example: a
  definition for lithium enriched to 90% in the isotope
  6Li, might have the name 'Li:90'.] These names/identifiers
  can be  used both in a mixture block of the input file
@@ -106,7 +106,7 @@ Format
 
    * a string indicating the name/identifier,
    * a floating point value for the weight fraction in %, and
-   * an integer for the :term:`atomic number` [G].
+   * an integer for the :term:`atomic number`.
 
 Example
 =======
@@ -115,7 +115,7 @@ Naming Material Definitions
 ===========================
 
  The name of a material definition must be a character string
- with no :term:`whitespace` [G]. The
+ with no :term:`whitespace`. The
  recommended practice is that material definitions never be
  deleted from a material library, ensuring the repeatability
  of results. It is expected, however, that many materials will
@@ -138,8 +138,8 @@ Waste Disposal Rating/Clearance Index
 Description
 ===========
 
- :term:`Waste disposal ratings <waste disposal rating>` [G] and
- :term:`clearance indices` [G] are used to
+ :term:`Waste disposal ratings <waste disposal rating>` and
+ :term:`clearance indices` are used to
  provide a single metric for classifying the level of control
  required when disposing of used material. Each metric is
  based on a (possibly) unique list of isotopes and the
@@ -153,11 +153,11 @@ Format
  simple text files containing one pair for each isotope for
  which a limit exists. The first entry of each pair identifies
  the isotope using either the standard :term:`chemical
- symbol` [G] notation CC-AAAM (CC is
+ symbol` notation CC-AAAM (CC is
  the chemical symbol, AAA is the mass number, and M is the
  isomeric state: 'm' for the first isomeric state, 'n' for
  the second, and so on), or ALARA's kza notation ZZAAAM (ZZ
- is the :term:`atomic number` [G], AAA is
+ is the :term:`atomic number`, AAA is
  the mass number, and M is the numerical isomeric state: '1'
  for the first state, '2' for the second, etc). The second
  entry is a specific activity in any combination of units

--- a/doc/usersguide/support.rst
+++ b/doc/usersguide/support.rst
@@ -25,7 +25,7 @@ Description
 ===========
 
  The element library allows the user to define the
- isotopic :doc:`[G] <glossarytext>` abundances
+ :term:`isotopic abundances` [G]
  to be used for each element. While this library
  should normally include a  definition of the natural
  abundances for each element, an extension is available
@@ -35,15 +35,16 @@ Format
 ======
 
  An element library can contain an arbitrary
- number :doc:`[G] <glossarytext>` of elemental
- definitions, each represented by a block with the following
- format. Every block must start with the following five entries: 
+ number of elemental definitions, each 
+ represented by a block with the following
+ format. Every block must start with the 
+ following five entries: 
 
    * a string indicating the name/identifier,
-   * a floating point value :doc:`[G] <glossarytext>` for the molar mass,
-   * an integer value for the atomic number :doc:`[G] <glossarytext>`,
+   * a :term:`floating point value <floating point scalar normalization>` [G] for the molar mass,
+   * an integer value for the :term:`atomic number` [G],
    * a floating point value for the theoretical density, and
-   * an integer value defining the number of isotopes :doc:`[G] <glossarytext>`.
+   * an integer value defining the number of :term:`isotopes <isotope>` [G].
 
  This is followed by two entries for each of these isotopes: 
 
@@ -57,15 +58,15 @@ Naming Elemental Definitions
 ============================
 
  The names/identifiers for all elemental definitions must
- be derived from the chemical symbol :doc:`[G] <glossarytext>`
+ be derived from the :term:`chemical symbol` [G]
  for that element, using the format ZZ[:AAA...], where ZZ
- represents the chemcial symbol :doc:`[G] <glossarytext>`,
+ represents the :term:`chemical symbol` [G],
  and [:AAA...] represents an optional modifier, separated by a
  colon, ':', from the chemical symbol. By  convention, entries
- without modifiers are used to define the natural
- abundances :doc:`[G] <glossarytext>` of isotopes. The
+ without modifiers are used to define the :term:`natural
+ abundances` [G] of isotopes. The
  modifier must be a character string containing no
- whitespace :doc:`[G] <glossarytext>`. [example: a
+ :term:`whitespace` [G]. [example: a
  definition for lithium enriched to 90% in the isotope
  6Li, might have the name 'Li:90'.] These names/identifiers
  can be  used both in a mixture block of the input file
@@ -105,7 +106,7 @@ Format
 
    * a string indicating the name/identifier,
    * a floating point value for the weight fraction in %, and
-   * an integer for the atomic number :doc:`[G] <glossarytext>`.
+   * an integer for the :term:`atomic number` [G].
 
 Example
 =======
@@ -114,7 +115,7 @@ Naming Material Definitions
 ===========================
 
  The name of a material definition must be a character string
- with no whitespace :doc:`[G] <glossarytext>`. The
+ with no :term:`whitespace` [G]. The
  recommended practice is that material definitions never be
  deleted from a material library, ensuring the repeatability
  of results. It is expected, however, that many materials will
@@ -137,8 +138,8 @@ Waste Disposal Rating/Clearance Index
 Description
 ===========
 
- Waste disposal ratings :doc:`[G] <glossarytext>` and
- clearance indices :doc:`[G] <glossarytext>` are used to
+ :term:`Waste disposal ratings <waste disposal rating>` [G] and
+ :term:`clearance indices` [G] are used to
  provide a single metric for classifying the level of control
  required when disposing of used material. Each metric is
  based on a (possibly) unique list of isotopes and the
@@ -151,12 +152,12 @@ Format
  either a volumetric or specific activity. These files are
  simple text files containing one pair for each isotope for
  which a limit exists. The first entry of each pair identifies
- the isotope using either the standard chemical
- symbol :doc:`[G] <glossarytext>` notation CC-AAAM (CC is
+ the isotope using either the standard :term:`chemical
+ symbol` [G] notation CC-AAAM (CC is
  the chemical symbol, AAA is the mass number, and M is the
  isomeric state: 'm' for the first isomeric state, 'n' for
  the second, and so on), or ALARA's kza notation ZZAAAM (ZZ
- is the atomic number :doc:`[G] <glossarytext>` , AAA is
+ is the :term:`atomic number` [G], AAA is
  the mass number, and M is the numerical isomeric state: '1'
  for the first state, '2' for the second, etc). The second
  entry is a specific activity in any combination of units


### PR DESCRIPTION
Rewrote `glossary.rst` and redid all user guide file's links to the glossary to now use the Sphinx engine auto glossary. Tested the build successfully using the `doc.Makefile`.