### PR TITLE
Fix doc build

### DIFF
--- a/Makefile.h
+++ b/Makefile.h
@@ -3,6 +3,7 @@
 
 # where to put documentation, data and sample input/output
 docdir = $(prefix)/doc
+ugdir = $(docdir)/usersguide
 nonxsdir = $(prefix)/data
 xsdir = $(prefix)/data
 sampledir = $(prefix)/sample

--- a/configure.ac
+++ b/configure.ac
@@ -69,6 +69,7 @@ AC_CONFIG_FILES([Makefile
 		 tools/extract_pathways
 		 tools/summary
 		 doc/Makefile
+		 doc/usersguide/Makefile
 		 data/Makefile
 		 sample/Makefile
 		 sample/data/Makefile

--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -3,8 +3,19 @@
 include $(top_srcdir)/Makefile.h
 
 # list html files
-dist_doc_DATA = ALARA_Intro.html commandtext.html glossarytext.html		\
-	outputtext.html support.html Introset.html credittext.html	\
-	inputtext.html side.html Manual_syntax.html errortext.html	\
-	introtext.html sidebar.html
+dist_doc_DATA = NEWS.rst \
+	index.rst \
+	aboutdata.rst \
+	features.rst \
+	usersguide/commandtext.rst \
+	usersguide/introtext.rst \
+	usersguide/index.rst \
+	usersguide/errortext.rst \
+	usersguide/inputtext.rst \
+	usersguide/Manual_syntax.rst \
+	usersguide/outputtext.rst \
+	usersguide/support.rst \
+	usersguide/glossarytext.rst \
+	usersguide/credittext.rst \
+	installguide.rst
 

--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -2,20 +2,12 @@
 
 include $(top_srcdir)/Makefile.h
 
+SUBDIRS = usersguide
+
 # list html files
 dist_doc_DATA = NEWS.rst \
 	index.rst \
 	aboutdata.rst \
 	features.rst \
-	usersguide/commandtext.rst \
-	usersguide/introtext.rst \
-	usersguide/index.rst \
-	usersguide/errortext.rst \
-	usersguide/inputtext.rst \
-	usersguide/Manual_syntax.rst \
-	usersguide/outputtext.rst \
-	usersguide/support.rst \
-	usersguide/glossarytext.rst \
-	usersguide/credittext.rst \
 	installguide.rst
 

--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -4,7 +4,7 @@ include $(top_srcdir)/Makefile.h
 
 SUBDIRS = usersguide
 
-# list html files
+# list RST files
 dist_doc_DATA = NEWS.rst \
 	index.rst \
 	aboutdata.rst \

--- a/doc/usersguide/Makefile.am
+++ b/doc/usersguide/Makefile.am
@@ -1,0 +1,16 @@
+#$Id: Makefile.am,v 1.6 2004-01-29 08:10:25 wilsonp Exp $
+
+include $(top_srcdir)/Makefile.h
+
+# list RST files
+dist_doc_DATA = commandtext.rst \
+	introtext.rst \
+	index.rst \
+	errortext.rst \
+	inputtext.rst \
+	Manual_syntax.rst \
+	outputtext.rst \
+	support.rst \
+	glossarytext.rst \
+	credittext.rst
+

--- a/doc/usersguide/Makefile.am
+++ b/doc/usersguide/Makefile.am
@@ -3,7 +3,7 @@
 include $(top_srcdir)/Makefile.h
 
 # list RST files
-dist_doc_DATA = commandtext.rst \
+dist_ug_DATA = commandtext.rst \
 	introtext.rst \
 	index.rst \
 	errortext.rst \


### PR DESCRIPTION
Given recent changes in how documentation is provided, this fixes the build system to install appropriate RST files instead of the prior HTML files.
