### PR TITLE
New NJOY file cleanup PR

### DIFF
--- a/src/DataLib/fendl32B_retrofit/groupr_tools.py
+++ b/src/DataLib/fendl32B_retrofit/groupr_tools.py
@@ -247,7 +247,7 @@ def cleanup_njoy_files(output_path = 'njoy_ouput'):
         None
     """
 
-    njoy_files = ['groupr.inp', 'tape20', 'tape21']
+    njoy_files = [INPUT, 'tape20', 'tape21']
     for file in njoy_files:
         Path.unlink(Path(file))
     Path('output').rename(Path(output_path))

--- a/src/DataLib/fendl32B_retrofit/groupr_tools.py
+++ b/src/DataLib/fendl32B_retrofit/groupr_tools.py
@@ -233,3 +233,21 @@ def run_njoy(element, A, matb):
         ensure_gendf_markers(gendf_path, matb)
 
         return gendf_path
+
+def cleanup_njoy_files(output_path = 'njoy_ouput'):
+    """
+    Clean up repository from unnecessary intermediate files from NJOY run.
+    
+    Arguments:
+        output_path (str, optional): The save path for the NJOY output.
+            Defaults to 'njoy_output', which will save the file in the
+            same directory as all other saved files from the script run.
+    
+    Returns:
+        None
+    """
+
+    njoy_files = ['groupr.inp', 'tape20', 'tape21']
+    for file in njoy_files:
+        Path.unlink(Path(file))
+    Path('output').rename(Path(output_path))

--- a/src/DataLib/fendl32B_retrofit/process_fendl3.2.py
+++ b/src/DataLib/fendl32B_retrofit/process_fendl3.2.py
@@ -17,6 +17,7 @@ def main():
     njoy_input = groupr_tools.fill_input_template(material_id, MTs, 'Fe', 56, mt_dict)
     groupr_tools.write_njoy_input_file(njoy_input)
     groupr_tools.run_njoy('Fe', 56, material_id)
+    groupr_tools.cleanup_njoy_files()
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
Closes #53.

I messed up my last rebase and because our conversation was pretty brief on the PR (#64), I just restarted it with the newest changes from the latest suggested changes.

Creates a method to delete the NJOY input file and the "tapes" that it processes (i.e. the starting ENDF and PENDF files and the converted GENDF file). The GENDF file saved under the name tape31 can be safely deleted because another copy of the file is saved separately in the function run_njoy with a more descriptive name anyways.

This method also renames the automated NJOY output file.