### PR TITLE
Extracting cross section data from GENDF files

### DIFF
--- a/src/DataLib/fendl32B_retrofit/groupr_tools.py
+++ b/src/DataLib/fendl32B_retrofit/groupr_tools.py
@@ -91,7 +91,7 @@ def fill_input_template(material_id, MTs, element, A, mt_dict):
 
     card9_lines = []
     MFD = 3 # ENDF file tag for cross-section data
-    for MT in MTs & mt_dict.keys():
+    for MT in MTs:
         mtname = mt_dict[MT]['Reaction']
         card9_lines.append(f'{MFD} {MT} "{mtname}" /') 
     card9 = '\n '.join(card9_lines)

--- a/src/DataLib/fendl32B_retrofit/groupr_tools.py
+++ b/src/DataLib/fendl32B_retrofit/groupr_tools.py
@@ -91,9 +91,10 @@ def fill_input_template(material_id, MTs, element, A, mt_dict):
 
     card9_lines = []
     for MT in MTs:
-        mtname = mt_dict[MT]['Reaction']
-        MFD = 3 # ENDF file tag for cross-section data
-        card9_lines.append(f'{MFD} {MT} "{mtname}" /') 
+        if MT in mt_dict.keys():
+            mtname = mt_dict[MT]['Reaction']
+            MFD = 3 # ENDF file tag for cross-section data
+            card9_lines.append(f'{MFD} {MT} "{mtname}" /') 
     card9 = '\n '.join(card9_lines)
     return njoy_input.substitute(
         mat_id=material_id,

--- a/src/DataLib/fendl32B_retrofit/groupr_tools.py
+++ b/src/DataLib/fendl32B_retrofit/groupr_tools.py
@@ -90,11 +90,10 @@ def fill_input_template(material_id, MTs, element, A, mt_dict):
     title = f'"{Z}-{element}-{A} for TENDL 2017"'
 
     card9_lines = []
-    for MT in MTs:
-        if MT in mt_dict.keys():
-            mtname = mt_dict[MT]['Reaction']
-            MFD = 3 # ENDF file tag for cross-section data
-            card9_lines.append(f'{MFD} {MT} "{mtname}" /') 
+    MFD = 3 # ENDF file tag for cross-section data
+    for MT in MTs & mt_dict.keys():
+        mtname = mt_dict[MT]['Reaction']
+        card9_lines.append(f'{MFD} {MT} "{mtname}" /') 
     card9 = '\n '.join(card9_lines)
     return njoy_input.substitute(
         mat_id=material_id,

--- a/src/DataLib/fendl32B_retrofit/process_fendl3.2.py
+++ b/src/DataLib/fendl32B_retrofit/process_fendl3.2.py
@@ -20,6 +20,10 @@ def main():
     groupr_tools.cleanup_njoy_files()
 
     pKZA = tp.extract_gendf_pkza(gendf_path)
+    # Extract MT values again from GENDF file as there may be some difference
+    # from the original MT values in the ENDF/PENDF files
+    endftk_file_obj, MTs = tp.extract_endf_specs(gendf_path, 'GENDF')
+    gendf_data = tp.iterate_MTs(MTs, endftk_file_obj, mt_dict, pKZA)
 
 if __name__ == '__main__':
     main()

--- a/src/DataLib/fendl32B_retrofit/process_fendl3.2.py
+++ b/src/DataLib/fendl32B_retrofit/process_fendl3.2.py
@@ -14,6 +14,7 @@ def main():
     pendf_path = 'tape21'
 
     material_id, MTs, endftk_file_obj = tp.extract_endf_specs(endf_path)
+    MTs = list(set(MTs).intersection(mt_dict.keys()))
     njoy_input = groupr_tools.fill_input_template(material_id, MTs, 'Fe', 56, mt_dict)
     groupr_tools.write_njoy_input_file(njoy_input)
     gendf_path = groupr_tools.run_njoy('Fe', 56, material_id)

--- a/src/DataLib/fendl32B_retrofit/process_fendl3.2.py
+++ b/src/DataLib/fendl32B_retrofit/process_fendl3.2.py
@@ -13,17 +13,19 @@ def main():
     endf_path = 'tape20'
     pendf_path = 'tape21'
 
-    material_id, MTs = tp.extract_endf_specs(endf_path)
+    material_id, MTs, endftk_file_obj = tp.extract_endf_specs(endf_path)
     njoy_input = groupr_tools.fill_input_template(material_id, MTs, 'Fe', 56, mt_dict)
     groupr_tools.write_njoy_input_file(njoy_input)
     gendf_path = groupr_tools.run_njoy('Fe', 56, material_id)
-    groupr_tools.cleanup_njoy_files()
 
     pKZA = tp.extract_gendf_pkza(gendf_path)
     # Extract MT values again from GENDF file as there may be some difference
     # from the original MT values in the ENDF/PENDF files
-    endftk_file_obj, MTs = tp.extract_endf_specs(gendf_path, 'GENDF')
+    material_id, MTs, endftk_file_obj = tp.extract_endf_specs(gendf_path)
     gendf_data = tp.iterate_MTs(MTs, endftk_file_obj, mt_dict, pKZA)
+    gendf_data.to_csv('gendf_data.csv')
+    groupr_tools.cleanup_njoy_files()
+
 
 if __name__ == '__main__':
     main()

--- a/src/DataLib/fendl32B_retrofit/reaction_data.py
+++ b/src/DataLib/fendl32B_retrofit/reaction_data.py
@@ -192,7 +192,7 @@ def process_mt_data(mt_dict):
             }
     """
 
-    for MT, data in mt_dict.items():
+    for MT, data in list(mt_dict.items()):
         emitted_particles = data['Reaction'].split(',')[1][:-1]
         emission_dict = emission_breakdown(emitted_particles)
         change_NP = nucleon_changes(emission_dict)
@@ -205,8 +205,8 @@ def process_mt_data(mt_dict):
         if change_NP is not None:
             change_N, change_P = change_NP
             data['delKZA'] = (change_P * 1000 + change_P + change_N) * 10 + M
+            data['Emitted Particles'] = emitted_particles
         else:
-            data['delKZA'] = 'N/A'
-        data['Emitted Particles'] = emitted_particles
-    
+            del mt_dict[MT]
+
     return mt_dict

--- a/src/DataLib/fendl32B_retrofit/tendl_processing.py
+++ b/src/DataLib/fendl32B_retrofit/tendl_processing.py
@@ -112,12 +112,10 @@ def iterate_MTs(MTs, file_obj, mt_dict, pKZA):
 
     for MT in MTs:
         sigma_list = extract_cross_sections(file_obj, MT)
-        if mt_dict[MT]['delKZA'] == 'N/A':
-            dKZA = 'N/A'
-        else:
-            dKZA = pKZA - mt_dict[MT]['delKZA']
+        dKZA = pKZA + mt_dict[MT]['delKZA']
         emitted_particles = mt_dict[MT]['Emitted Particles']
         cross_sections_by_MT.append(sigma_list)
+        
         dKZAs.append(dKZA)
         emitted_particles_list.append(emitted_particles)
         groups.append(len(sigma_list))

--- a/src/DataLib/fendl32B_retrofit/tendl_processing.py
+++ b/src/DataLib/fendl32B_retrofit/tendl_processing.py
@@ -32,8 +32,6 @@ def extract_endf_specs(path, filetype = 'ENDF'):
     else:
         return matb, MTs
 
-    return (endf_specs)
-
 def extract_gendf_pkza(gendf_path):
     """
     Read in and parse the contents of a GENDF file to construct the parent

--- a/src/DataLib/fendl32B_retrofit/tendl_processing.py
+++ b/src/DataLib/fendl32B_retrofit/tendl_processing.py
@@ -2,14 +2,12 @@
 import ENDFtk
 import pandas as pd
 
-def extract_endf_specs(path, filetype = 'ENDF'):
+def extract_endf_specs(path):
     """
     Extract the material ID and MT numbers from an ENDF file.
 
     Arguments:
         path (str): File path to the selected ENDF file.
-        filetype (str, optional): Either ENDF or GENDF (case insensitive).
-            Defaults to 'ENDF'.
     
     Returns:
         matb (int): Unique material ID extracted from the file.
@@ -27,10 +25,7 @@ def extract_endf_specs(path, filetype = 'ENDF'):
     # Extract the MT numbers that are present in the file
     MTs = [MT.MT for MT in file.sections.to_list()]
     
-    if filetype.lower() == 'gendf':
-        return file, MTs
-    else:
-        return matb, MTs
+    return (matb, MTs, file)
 
 def extract_gendf_pkza(gendf_path):
     """
@@ -81,7 +76,7 @@ def extract_cross_sections(file, MT):
 
     # Only every 2nd line starting at the 3rd line has cross-section data.
     lines = section.split('\n')[2:-2:2]
-
+    
     # Extract the 3rd token and convert to more conventional string
     # representation of a float
     sigma_list = [

--- a/src/DataLib/fendl32B_retrofit/tendl_processing.py
+++ b/src/DataLib/fendl32B_retrofit/tendl_processing.py
@@ -1,16 +1,22 @@
 # Import packages
 import ENDFtk
+import pandas as pd
 
-def extract_endf_specs(path):
+def extract_endf_specs(path, filetype = 'ENDF'):
     """
     Extract the material ID and MT numbers from an ENDF file.
 
     Arguments:
         path (str): File path to the selected ENDF file.
+        filetype (str, optional): Either ENDF or GENDF (case insensitive).
+            Defaults to 'ENDF'.
     
     Returns:
         matb (int): Unique material ID extracted from the file.
         MTs (list): List of reaction types (MT's) present in the file.
+        file (ENDFtk.tree.File or None): ENDFtk file object containing the
+            contents for a specific material's cross-section data.
+            Only returns the file for GENDF filetypes.
     """
 
     tape = ENDFtk.tree.Tape.from_file(path)
@@ -21,7 +27,12 @@ def extract_endf_specs(path):
     # Extract the MT numbers that are present in the file
     MTs = [MT.MT for MT in file.sections.to_list()]
     
-    return matb, MTs
+    if filetype.lower() == 'gendf':
+        return file, MTs
+    else:
+        return matb, MTs
+
+    return (endf_specs)
 
 def extract_gendf_pkza(gendf_path):
     """
@@ -50,3 +61,80 @@ def extract_gendf_pkza(gendf_path):
     A = int(A.lower().split(' ')[0].split('m')[0])
     pKZA = (Z * 1000 + A) * 10 + M
     return pKZA
+
+def extract_cross_sections(file, MT):
+    """
+    Parse through the contents of a GENDF file section to extract the
+        cross-section data for a specific reaction type (MT).
+    
+    Arguments:
+        file (ENDFtk.tree.File): ENDFtk file object containing a specific
+            material's cross-section data.
+        MT (int): Numerical identifier for the reaction type corresponding to
+            the file's sectional organization.
+    
+    Returns:
+        sigma_list (list): All of the cross-sections for a given reaction type
+            and material, listed as floating point numbers. If the run fails,
+            the function will just return an empty list.
+    """
+
+    section = file.section(MT).content
+
+    # Only every 2nd line starting at the 3rd line has cross-section data.
+    lines = section.split('\n')[2:-2:2]
+
+    # Extract the 3rd token and convert to more conventional string
+    # representation of a float
+    sigma_list = [
+        float(line.split(' ')[2].replace('+','E+').replace('-','E-'))
+        for line in lines
+    ]
+
+    return sigma_list
+
+def iterate_MTs(MTs, file_obj, mt_dict, pKZA):
+    """
+    Iterate through all of the MTs present in a given GENDF file to extract
+        the necessary data to be able to run ALARA.
+    
+    Arguments:
+        MTs (list of int): List of reaction types present in the GENDF file.
+        file_obj (ENDFtk.tree.File): ENDFtk file object containing the
+            contents for a specific material's cross-section data.
+        mt_dict (dict): Dictionary formatted data structure for mt_table.csv
+        pKZA (int): Parent KZA identifier.
+
+    Returns:
+        gendf_data (pandas.core.frame.DataFrame): Pandas DataFrame containing
+            parent KZA values, daughter KZA values, emitted particles,
+            counts of the number of non-zero groups in the Vitamin-J groupwise
+            structure, and the cross-section values for those groups.
+    """
+
+    cross_sections_by_MT    =    []
+    emitted_particles_list  =    []
+    dKZAs                   =    []
+    groups                  =    []
+
+    for MT in MTs:
+        sigma_list = extract_cross_sections(file_obj, MT)
+        if mt_dict[MT]['delKZA'] == 'N/A':
+            dKZA = 'N/A'
+        else:
+            dKZA = pKZA - mt_dict[MT]['delKZA']
+        emitted_particles = mt_dict[MT]['Emitted Particles']
+        cross_sections_by_MT.append(sigma_list)
+        dKZAs.append(dKZA)
+        emitted_particles_list.append(emitted_particles)
+        groups.append(len(sigma_list))
+
+    gendf_data = pd.DataFrame({
+        'Parent KZA'            :       [pKZA] * len(dKZAs),
+        'Daughter KZA'          :       dKZAs,
+        'Emitted Particles'     :       emitted_particles_list,
+        'Non-Zero Groups'       :       groups,
+        'Cross Sections'        :       cross_sections_by_MT
+    })
+
+    return gendf_data


### PR DESCRIPTION
Closes #48.

Creates a method for extracting the cross section data from a GENDF file by MT number and another method to iterate through all of the given MT numbers in the GENDF file to call this method.

Makes small modifications to `extract_endf_specs()` to make it more versatile and usable for a GENDF file, which needs to be done so that the updated MT values are used (some MT numbers present in the preprocessed ENDF/PENDF files do not remain after processing with GROUPR).