### PR TITLE
Fixing order of cross section data for FENDL3.2b retrofit

### DIFF
--- a/src/DataLib/fendl32B_retrofit/tendl_processing.py
+++ b/src/DataLib/fendl32B_retrofit/tendl_processing.py
@@ -143,7 +143,7 @@ def extract_cross_sections(file, MT):
         for line in lines
     ]
 
-    return sigma_list
+    return sigma_list[::-1]
 
 def iterate_MTs(MTs, file_obj, mt_dict, pKZA):
     """


### PR DESCRIPTION
Reverses the order of the `sigma_list` list in `tendl_processing.py` for the FENDL3.2b retrofit. After comparing the data produced through the GROUPR processing in this retrofit with FENDL2.0 data, the shapes of the plots were flipped, implying that the way that the cross sections were being saved in the retrofit was in reverse order. Upon reversing the order of the list, the two plots matched very closely. 

I will include a full comparison script either in this PR or another, depending on your preference @gonuke, but either way, this seems to be a necessary fix regardless.