### PR TITLE
Set C++11 as C++ Standard

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,6 @@
 project(ALARA)
 cmake_minimum_required(VERSION 2.8)
+set (CMAKE_CXX_STANDARD 11)
 
 # Default to a release build
 if (NOT CMAKE_BUILD_TYPE)


### PR DESCRIPTION
On some systems, cmake assumes by default the C++17 standard for compilation. However, the dynamic exception specifications are not allowed in the C++17 standard (and deprecated since C++11).

The scope of the commit is to set the C++11 standard in the CMakeLists.txt file.