### PR TITLE
NJOY Error Handling in ALARAJOYWrapper

### DIFF
--- a/tools/ALARAJOYWrapper/groupr_tools.py
+++ b/tools/ALARAJOYWrapper/groupr_tools.py
@@ -230,8 +230,13 @@ def run_njoy(element, A, matb):
         matb (int): Unique material ID for the material in the files.
     
     Returns:
-        gendf_path (str): File path to the newly created GENDF file. 
+        gendf_path (str or None): File path to the newly created GENDF file.
+                                    Returns None if NJOY runs unsuccessfuly.
+        result.stderr (str or None): Output of NJOY error.
+                                    Returns None if NJOY runs successfully. 
     """
+
+    gendf_path = None
 
     # Run NJOY
     result = subprocess.run(['njoy'], input=open(INPUT).read(),
@@ -247,9 +252,7 @@ def run_njoy(element, A, matb):
         Path('tape31').rename(Path(gendf_path))
         ensure_gendf_markers(gendf_path, matb)
 
-        return gendf_path
-    else:
-        print(result.stderr)
+    return gendf_path, result.stderr
 
 def cleanup_njoy_files(output_path = dir + '/njoy_ouput'):
     """

--- a/tools/ALARAJOYWrapper/tendl_processing.py
+++ b/tools/ALARAJOYWrapper/tendl_processing.py
@@ -110,17 +110,13 @@ def extract_gendf_pkza(gendf_path):
     # Metastable states classified by TENDL as m = 1, n = 2, etc.
     # (Generally expecting only m, occasionally n, but physically,
     # values could go higher, so isomeric_states goes up to z = 14)
-    isomeric_states = [
-        'm', 'n', 'o', 'p', 'q', 'r', 's', 't', 'u', 'v', 'w', 'x', 'y', 'z'
-    ]
-    isomeric_states = dict(
-        zip(isomeric_states, range(1, len(isomeric_states)+1))
-    )
+    M = 0
+    isomeric_states = 'mnopqrstuvwxyz'
     isomer_tag = next(
         (tag for tag in isomeric_states if tag in A.lower()), None
     )
-    # If no isomeric tag found, then the excitation level is 0
-    M = isomeric_states.get(isomer_tag, 0)
+    if isomer_tag:
+        M = isomeric_states.find(isomer_tag) + 1
     if M > 2:
         warnings.warn(
             f'Isomeric state greater than 2. Unexpected case for TENDL2017.',


### PR DESCRIPTION
When processing the entire TENDL2017 neutron activation database through `preprocess_fendl3.py`, a number of isotopes failed to be run through `GROUPR`. Unfortunately NJOY gave a fairly opaque error message, just reading:

> STOP 77

Upon review of the [NJOY User Manual](https://github.com/njoy/NJOY2016-manual/raw/master/njoy16.pdf), the only reference to this error code is:
> The default versions of error and mess simply write the one or two lines of message characters to the appropriate units. The Fortran-90 len_trim function is used to measure the real length of a character string by removing trailing blanks. By changing nsyse, messages can be directed to the user’s terminal, to a standard error unit, or left to appear on the output file only. The default fatal error exit “stop 77” can be sometimes be changed to cause a “traceback” to the subroutine that called error, and backward through the stack of subroutines that called it. Also, some systems can cause a drop file or “core” file to be generated for post-mortem analysis with a debugging program.

It seems that there are only a few isotopes for which this has happened, notably a number of U and Th isotopes. I did not notice any fusion relevant isotopes failing to be processed, so I figured that this was not necessarily worth such a deep dive into the NJOY rabbit hole to find the source of the `STOP 77` error, and rather to allow for `preprocess_fendl3.py` to just warn the user and keep moving on.