### PR TITLE
Add command line option to redirect output to file instead of terminal

### DIFF
--- a/src/Input.C
+++ b/src/Input.C
@@ -53,7 +53,7 @@ Input::Input(char* inputFname)
 {
   if (inputFname != NULL)
     {
-      debug(1,"Openning %s for input.",inputFname);
+      debug(1,"Opening %s for input.",inputFname);
       input = openFile(inputFname);
       if (!*input)
 	error(102,"Unable to open main input file: '%s'.",inputFname);
@@ -62,7 +62,7 @@ Input::Input(char* inputFname)
     }
   else
     {
-      debug(1,"Openning stdin for input.");
+      debug(1,"Opening stdin for input.");
       input = &cin;
       verbose(1,"Opened stdin for input.");
     }
@@ -247,7 +247,7 @@ void Input::read()
 		  outList = outList->getOutFmts(*input);
 		  break;
 		case INTOK_DUMPFILE:
-		  debug(1,"Openning dump filename.");
+		  debug(1,"Opening dump filename.");
 		  *input >> token;
 		  Result::initBinDump(token);
 		  break;
@@ -519,7 +519,7 @@ void Input::clearIncludeComment()
 	    streamStack << input;
 
 
-	    verbose(2,"Openning included file: %s.",inFileName);
+	    verbose(2,"Opening included file: %s.",inFileName);
 	    /* open new stream */
 	    /* Allow inclusion of files from a search path
 	     * This allows standard elements of an input file

--- a/src/alara.C
+++ b/src/alara.C
@@ -162,7 +162,7 @@ int main(int argc, char *argv[])
         } 
 		else 
 			{
-            error(1, "-o requires parameter.");
+            error(2, "-o requires parameter.");
         }
     } 
 	else 

--- a/src/alara.C
+++ b/src/alara.C
@@ -156,7 +156,7 @@ int main(int argc, char *argv[])
            		outfile.open(out_file);
             	if (!outfile.is_open())
                 	error(1, "Cannot create output file %s.", out_file.c_str());
-            	oldbuf = std::cout.rdbuf(outfile.rdbuf());
+            	std::cout.rdbuf(outfile.rdbuf());
             	verbose(0, "Verbose output redirected to %s", out_file.c_str());
             	argNum += 2;
         } 
@@ -171,7 +171,7 @@ int main(int argc, char *argv[])
         	outfile.open(out_file);
         	if (!outfile.is_open())
             	error(1, "Cannot create output file %s.", out_file.c_str());
-        	oldbuf = std::cout.rdbuf(outfile.rdbuf()); // redirect cout
+        	std::cout.rdbuf(outfile.rdbuf());
         	verbose(0, "Verbose output redirected to %s", out_file.c_str());
         	argNum++;
     	}

--- a/src/alara.C
+++ b/src/alara.C
@@ -33,12 +33,14 @@ usage: %s [-h] [-r] [-t <tree_filename>] [-V] [-v <n>] [<input_filename>] [-o <o
 \t -V                 Show version\n\
 \t -v <n>             Set verbosity level\n\
 \t <input_filename>   Name of input file\n\
-\t <output_filename>  Name of output file\n\
+\t <output_filename>  Name of file in which output is written (optional)\n\
 See Users' Guide for more info.\n\
 (http://alara.engr.wisc.edu/)\n";
 
 int main(int argc, char *argv[])
-{
+{  
+  std::string out_file;
+  std::ofstream outfile;
   int argNum = 1; /// count command-line arguments
   int solved = FALSE; /// command-line derived flag to indicate whether or not the tree has already been solved
   int doOutput = TRUE; /// command-line derived flag to indicate whether or not to post-process solution
@@ -145,6 +147,35 @@ int main(int argc, char *argv[])
 	      argNum++;
 	    }
 	  break;
+    case 'o':
+    if (argv[argNum][1] == '\0') 
+		{
+        if (argNum<argc-1) 
+			{
+            	out_file = argv[argNum+1]; 
+           		outfile.open(out_file);
+            	if (!outfile.is_open())
+                	error(1, "Cannot create output file %s.", out_file.c_str());
+            	oldbuf = std::cout.rdbuf(outfile.rdbuf());
+            	verbose(0, "Verbose output redirected to %s", out_file.c_str());
+            	argNum += 2;
+        } 
+		else 
+			{
+            error(1, "-o requires parameter.");
+        }
+    } 
+	else 
+		{
+        	out_file = argv[argNum]+1; 
+        	outfile.open(out_file);
+        	if (!outfile.is_open())
+            	error(1, "Cannot create output file %s.", out_file.c_str());
+        	oldbuf = std::cout.rdbuf(outfile.rdbuf()); // redirect cout
+        	verbose(0, "Verbose output redirected to %s", out_file.c_str());
+        	argNum++;
+    	}
+    break;
 	case 'h':
 	  verbose(-1,helpmsg,argv[0]);
 	case 'V':

--- a/src/alara.C
+++ b/src/alara.C
@@ -25,7 +25,7 @@ pu am cm bk cf es fm md no lr ";
  command-line option is used, or when -h is used.
 */
 static const char *helpmsg="\
-usage: %s [-h] [-r] [-t <tree_filename>] [-V] [-v <n>] [<input_filename>] \n\
+usage: %s [-h] [-r] [-t <tree_filename>] [-V] [-v <n>] [<input_filename>] [-o <output_filename>] \n\
 \t -h                 Show this message\n\
 \t -c                 Option to only calculate chains and skip post-processing\n\
 \t -r                 \"Restart\" option to skip chain calculation and only post-process\n\
@@ -33,6 +33,7 @@ usage: %s [-h] [-r] [-t <tree_filename>] [-V] [-v <n>] [<input_filename>] \n\
 \t -V                 Show version\n\
 \t -v <n>             Set verbosity level\n\
 \t <input_filename>   Name of input file\n\
+\t <output_filename>  Name of output file\n\
 See Users' Guide for more info.\n\
 (http://alara.engr.wisc.edu/)\n";
 


### PR DESCRIPTION
The option -o <output_filename> has been added to allow the user to redirect verbose output to an output file. The version string, however, stays in the terminal as the processing of command line input doesn't seem to start until this line is printed.

fixes #108 