### PR TITLE
Allowing ALARAJOYWrapper to be called from anywhere.

### DIFF
--- a/tools/ALARAJOYWrapper/groupr_tools.py
+++ b/tools/ALARAJOYWrapper/groupr_tools.py
@@ -13,11 +13,11 @@ def set_directory():
     Arguments:
         None
     Returns:
-        dir (str): Path to the current working directory (CWD) from which the
-            command was called.
+        dir (pathlib._local.PosixPath): Path to the current working directory
+            (CWD) from which the command was called.
     '''
 
-    return str(Path(__file__).resolve().parent)
+    return Path(__file__).resolve().parent
 
 # Define constant(s)
 dir = set_directory()


### PR DESCRIPTION
Closes #96 .

Modifies `set_directory()` in `groupr_tools.py` to locate the directory `ALARAJOYWrapper` from anywhere, so that the user can call the preprocessor from anywhere.