### PR TITLE
Comparison Tool Part 1: Simulation Tools for Single Element Comparison Tool

### DIFF
--- a/tools/ALARAJOYWrapper/alarajoy_QA.py
+++ b/tools/ALARAJOYWrapper/alarajoy_QA.py
@@ -1,0 +1,109 @@
+import subprocess
+from string import Template
+from pathlib import Path
+
+#--------------- Running Single Parent Element Simulation(s) -----------------
+
+INPUT = 'alara.inp'
+
+# Adapted from ALARA/examples/singleElement.ala
+alara_input = Template(
+'''
+geometry rectangular
+dimension	x
+		0.0
+        1       5.0
+end
+mat_loading
+        inner_zone1  mix1
+end
+material_lib ../../data/matlib.sample
+element_lib ../../data/nuclib.std
+data_library alaralib $datalib
+mixture mix1
+        element $element              1.0     1.00
+end
+flux flux_1 ../../examples/ref_flux_files/fluxfnsfIBfw_518MW.txt  1.0   0   default
+schedule 2_year
+	2 y  flux_1  steady_state  0 s
+end
+pulsehistory steady_state
+	1	0 s
+end
+dump_file dump_singleElement
+cooling
+	1e-5 y
+	1e-2 y
+	1 y
+	100 y
+	10000 y
+end
+output interval
+        units Bq kg
+        number_density
+        specific_activity
+	total_heat
+	dose contact $datalib ../../data/ANS6_4_3
+end
+## 
+truncation  1e-7
+'''
+)
+
+def fill_alara_template(element, datalib):
+    '''
+    Substitute in the specific single parent element and path to a
+        pre-converted ALARA binary library, such as that for either FENDL2 or
+        ALARAJOY-processed FENDL3, to a template containing a generalized
+        ALARA input file text for a simple single parent element simulation.
+    Arguments:
+        element (str): Single parent element to be irradiated.
+        datalib (str): Path to the binary library.
+    
+    Returns:
+        alara_input (str): String template with appropriate variables
+            substituted in for Template identifiers.
+    '''
+
+    return alara_input.substitute(element=element, datalib=datalib)
+
+def write_alara_input_file(template):
+    '''
+    Write out the ALARA input card from the prefilled template.
+    Arguments:
+        template (str): String template with appropriate variables substituted
+            in for Template identifiers.
+    Returns:
+        None
+    '''
+
+    with open(INPUT, 'w') as f:
+        f.write(template)
+
+def run_alara(element, libname):
+    '''
+    Invoke subprocess.run() to run ALARA for the single parent element
+        irradiation simulation. Specify destination for ALARA tree file and
+        capture stdout to an output file to be read by
+        alara_pandas_parser.parse_tables().
+    Arguments:
+        element (str): Single parent element to be irradiated.
+        libname (str): Name of the source data library (i.e. fendl2, fendl3,
+            etc.)
+    Returns:
+        output (str): Path to the ALARA redirected ALARA stdout formatted as a
+            text file.
+    '''
+
+    filename_base = f'{element}_{libname}'
+    output = f'{filename_base}.out'
+    Path(output).unlink(missing_ok=True)
+    with open(output, 'w') as outfile:
+        subprocess.run(
+            ['alara', '-t', f'{filename_base}.tree', '-v', '3', INPUT],
+            stdout=outfile,
+            stderr=subprocess.STDOUT,
+            check=True
+        )
+
+    return output

--- a/tools/ALARAJOYWrapper/alarajoy_QA_notebook.ipynb
+++ b/tools/ALARAJOYWrapper/alarajoy_QA_notebook.ipynb
@@ -1,0 +1,85 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "1112b209",
+   "metadata": {},
+   "source": [
+    "# **ALARAJOY Library Conversion QA Notebook**\n",
+    "\n",
+    "\n",
+    "This Jupyter Notebook is designed to enable comparisons for neutron activation responses of a given single parent element as calculated by ALARA for the purpose of validating ALARAJOY-processed data from the FENDL3.2x data sets."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3298730d",
+   "metadata": {},
+   "source": [
+    "**Import Packages**"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "57313772",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import alarajoy_QA as qa\n",
+    "import importlib"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d37d40a3",
+   "metadata": {},
+   "source": [
+    "**Run ALARA with each prepared binary data library**"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4eae0d85",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "importlib.reload(qa)\n",
+    "data_soure = {\n",
+    "    'fendl2' : '/groupspace/shared/n/nukecode/ALARA/data/fendl2bin',\n",
+    "    'fendl3' : '../../examples/data/fendl3'\n",
+    "}\n",
+    "\n",
+    "element = input('Select single parent element to evaluate: ').lower()\n",
+    "\n",
+    "for libname, binary in data_soure.items():\n",
+    "    alara_input = qa.fill_alara_template(element, binary)\n",
+    "    qa.write_alara_input_file(alara_input)\n",
+    "    output = qa.run_alara(element,libname)\n",
+    "    data_soure[libname] = output"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "base",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.13.5"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
Responding to the need to break up #135 into smaller PRs, this starts by creating a new Python module `alarajoy_QA.py` in `ALARAJOYWrapper/` to be called within a Jupyter notebook `alarajoy_QA_notebook.ipynb`. Overall, following the work that I had started on in #135 , this notebook will allow the user to select any single element, run a simple ALARA irradiation scenario modelled after `examples/Results_singleElement_Fe_FENDL2/singleElement.ala` with multiple data sets (although with specific focus on comparing ALARAJOY-processed FENDL3.2x data against FENDL2 data). 

This PR includes functions needed to prepare and execute these ALARA runs, which is done iteratively in the Jupyter notebook. As currently structured, to be able to produce two ALARA output files to compare from each dataset, the user first has to follow the instructions in `./README.md` to use ALARAJOYWrapper and ALARA's `convert_lib` to produce an ALARA binary library from FENDL3.2x data. From there, and with the path to said converted library, the user needs only to input which element they are interested in irradiating.