### PR TITLE
Comparison Tool Part 3: Versatile Plotting Tool and Some Basic Implementations

### DIFF
--- a/tools/ALARAJOYWrapper/alarajoy_QA.py
+++ b/tools/ALARAJOYWrapper/alarajoy_QA.py
@@ -481,7 +481,7 @@ def construct_legend(ax, data_comp=False):
 
 #---------------------------- Plotting functions -----------------------------
 
-def plot_single_element(
+def plot_single_response(
         df_dicts, 
         total=False, 
         element='', 

--- a/tools/ALARAJOYWrapper/alarajoy_QA_notebook.ipynb
+++ b/tools/ALARAJOYWrapper/alarajoy_QA_notebook.ipynb
@@ -290,13 +290,13 @@
     "**Plot for a single data source**\n",
     "\n",
     "Simple plot showing the top five contributors to number density from a single data source.\n",
-    "The function `aq.plot_single_element()` can be used either singularly or comparitavely between data libraries. To plot a single data source, for the `df_dicts` parameter, include one dictionary from `dfs`, selected by the general form:\n",
+    "The function `aq.plot_single_response()` can be used either singularly or comparitavely between data libraries. To plot a single data source, for the `df_dicts` parameter, include one dictionary from `dfs`, selected by the general form:\n",
     "     `df_dicts=dfs[f'{datalib} {variable}']` "
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 35,
+   "execution_count": null,
    "id": "8ae5e6e2",
    "metadata": {},
    "outputs": [
@@ -313,7 +313,7 @@
    ],
    "source": [
     "variable = 'Number Density'\n",
-    "qa.plot_single_element(\n",
+    "qa.plot_single_response(\n",
     "    dfs[f'fendl3 {variable}'],\n",
     "    total=False,\n",
     "    head=5,\n",
@@ -335,7 +335,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 37,
+   "execution_count": null,
    "id": "dd88ceae",
    "metadata": {},
    "outputs": [
@@ -351,7 +351,7 @@
     }
    ],
    "source": [
-    "qa.plot_single_element(\n",
+    "qa.plot_single_response(\n",
     "    [dfs[f'fendl3 {variable}'], dfs[f'fendl2 {variable}']],\n",
     "    head=6\n",
     ")"
@@ -378,7 +378,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 38,
+   "execution_count": null,
    "id": "3bf38ac7",
    "metadata": {},
    "outputs": [
@@ -429,7 +429,7 @@
     "]\n",
     "\n",
     "for variable in variables:\n",
-    "    qa.plot_single_element(\n",
+    "    qa.plot_single_response(\n",
     "        [dfs[f'fendl3 {variable}'], dfs[f'fendl2 {variable}']],\n",
     "        total=True,\n",
     "        head=1,\n",


### PR DESCRIPTION
Follow up to #143 .

This PR introduces the `plotting_single_response()` function to `alarajoy_QA.py`, which can produce plots of a given ALARA output variable against cooling times, either for a single data source or comparatively between multiple. The function includes a robust set of optional parameters to choose to plot specific daughter elements, filter out small contributors, show only total values, etc. 

For the actual example implementation of this function in the Jupyter notebook, however, I've included:

- A plot of a single data source's number density against time
- A plot comparing both data sources' number densities against time
- A plot comparing both data sources' gas production number densities against time
- Plots comparing total values for number density, specific activity, decay heat, and contact dose over time