### PR TITLE
ALARA Output Postprocessing Pyproject

### DIFF
--- a/tools/LICENSE.md
+++ b/tools/LICENSE.md
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 UW-Madison Computational Nuclear Engineering Research Group
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/tools/README.md
+++ b/tools/README.md
@@ -1,0 +1,68 @@
+# ALARA Output Processing
+
+Contained within `ALARA/tools` is the Python package, `alara_output_processing`, a module desgined for the parsing of ALARA output files into Pandas DataFrame-inherited structures, with a robust set of operations to organize and process data to user specifications.
+
+## Dependencies
+- Standard Python libraries
+    * [ArgParse](https://docs.python.org/3/library/argparse.html)
+    * [IO](https://docs.python.org/3/library/io.html)
+    * [Re](https://docs.python.org/3/library/re.html)
+- Generic Python packages
+    * [Pandas](https://pandas.pydata.org/docs/getting_started/install.html)
+
+
+## Installation
+```
+pip install alara_output_processing
+```
+
+## Usage
+`alara_output_processing` can be used either as a pure Python library, or as a command line tool. From the command line, calling `alara_output_processing` with the filepath to an ALARA output file will automatically identify and parse all text-formatted tables contained in the output file and write them out to individual CSV files (corresponding to each zone/interval of the ALARA run). To run `alara_output_processing` from the command line, run:
+```
+alara_output_processing -f /path/to/alara/output.txt
+```
+
+Alternatively, when used as a Python library, `alara_output_processing` can read in and parse ALARA output tables as such:
+```
+from alara_output_processing import FileParser, ALARADFrame, DataLibrary
+
+alara_data = FileParser('/path/to/alara/output.txt')
+output_tables = alara_data.extract_tables()
+```
+
+If comparing multiple ALARA runs, a dictionary can be constructed of the form:
+```
+runs = {
+    'run1' : '/path/to/run1/output.txt',
+    'run2' : '/path/to/run2/output.txt',
+}
+```
+
+This dictionary can be input directly into the function `DataLibrary.make_entries()` to create a list of dictionaries of all tabular data with the following command:
+```
+dfs = DataLibrary.make_entries(runs)
+```
+Wherein `dfs` contains entries for each table of the form:
+```
+df_dict = {
+    'Run Label'   : (Distinguisher between runs),
+    'Variable'    : (Any ALARA output variable, dependent on
+                    ALARA run parameters),
+    'Unit'        : (Respective unit matching the above
+                    variable),
+    'Data'        : (ALARADFrame containing ALARA output data
+                    for the given run parameter, variable, and
+                    unit)
+}
+```
+
+Once processed, the following operations are available on any given `ALARADFrame`:
+
+* `ALARADFrame.process_time_vals()`
+    - Convert the cooling times of the ALARA analysis post-shutdown to floating point numbers, in either seconds or years.
+* `ALARADFrame.extract_totals()`
+    - Select the values from the "total" row of an ALARA output table ALARADFrame and write them out to a list.
+* `ALARADFrame.filter_elements()`
+    - Create a new ALARADFrame containing only the data for nuclides of a selected element or elements.
+* `ALARADFrame.aggregate_small_percentages()`
+    - Consolidate all rows in an ALARADFrame that do not have any cells with a contribution of more than a threshold value to the total for its respective column. Rows that do not have any cells that surpass its column's threshold are aggregated into a new "Other" row. If a row has at least one column value above the threshold, then the whole row is preserved.

--- a/tools/alara_output_processing/__init__.py
+++ b/tools/alara_output_processing/__init__.py
@@ -1,0 +1,8 @@
+from .alara_output_processing import (
+    FileParser,
+    ALARADFrame,
+    DataLibrary
+)
+
+__version__ = '0.0.1'
+__all__ = ['FileParser', 'ALARADFrame', 'DataLibrary']

--- a/tools/alara_output_processing/alara_output_processing.py
+++ b/tools/alara_output_processing/alara_output_processing.py
@@ -60,7 +60,6 @@ class FileParser:
                     represented in the table (e.g. specific activity, number
                     density, etc.)
                 current_interval (str): Interval iterated upon in ALARA run.
-
             Returns:
                 None
             '''
@@ -77,10 +76,8 @@ class FileParser:
         '''
         Reads an ALARA output file, identifies all data tables contained
             within, and stores each as an ALARADFrame in a dictionary.
-
         Arguments:
             self (alara_output_processing.FileParser): FileParser object.
-
         Returns:
             results (dict): Dictionary that stores all parsed tables,
                 keyed by parameter and block name.
@@ -127,13 +124,13 @@ class FileParser:
                 continue
 
         return self.results
-    
+
     # ---------- Output ----------
     def write_csv_files(self):
         '''
         Write out all ALARADFrames extracted from parsed ALARA output tables
             to their own CSV files.
-
+            
         Arguments:
             self (alara_output_processing.FileParser): FileParser object.
         
@@ -158,7 +155,6 @@ class ALARADFrame(pd.DataFrame):
         '''
         Convert the cooling times of the ALARA analysis post-shutdown to
             floating point numbers, in either seconds or years.
-
         Arguments:
             self (alara_output_processing.ALARADFrame): Specialized ALARA
                 output DataFrame containing the extracted tabular data for a
@@ -166,7 +162,6 @@ class ALARADFrame(pd.DataFrame):
             seconds (bool, optional): Option to convert cooling times from
                 years to seconds.
                 (Defaults to True)
-
         Returns:
             times (list): List of the ALARA cooling times, written as 
                 floating point numbers of seconds or years.
@@ -184,7 +179,7 @@ class ALARADFrame(pd.DataFrame):
                 times.append(float(time) * time_dict['y'])
 
         return times
-    
+
     def extract_totals(self):
         '''
         Select the values from the "total" row of an ALARA output table
@@ -194,7 +189,6 @@ class ALARADFrame(pd.DataFrame):
             self (alara_output_processing.ALARADFrame): Specialized ALARA
                 output DataFrame containing the extracted tabular data for a
                 single variable and interval/zone of an ALARA run.
-
         Returns:
             totals (list): List of floating point numbers of the total values
                 for the given response, with length equal to the number of
@@ -202,7 +196,7 @@ class ALARADFrame(pd.DataFrame):
         '''
 
         return self[self['isotope'] == 'total'].iloc[0, 1:].tolist()
-    
+
     def filter_elements(self, elements):
         '''
         Create a new ALARADFrame containing only the data for nuclides of a
@@ -214,7 +208,6 @@ class ALARADFrame(pd.DataFrame):
                 single variable and interval/zone of an ALARA run.
             elements (str or list): Option to plot only the isotopes of a
                 single element or list of selected elements.
-
         Returns:
             element_df (alara_output_processing.ALARADFrame): New ALARADFrame
                 containing only rows for the selected element(s).
@@ -226,7 +219,7 @@ class ALARADFrame(pd.DataFrame):
         regex = '|'.join(fr'{el}-' for el in elements)
 
         return self[self['isotope'].str.contains(regex, case=False, na=False)]
-    
+
     def aggregate_small_percentages(self, relative=False, threshold=0.05):
         '''
         Consolidate all rows in an ALARADFrame that do not have any cells with
@@ -274,7 +267,7 @@ class ALARADFrame(pd.DataFrame):
 
 
 class DataLibrary:
-    
+
     @staticmethod
     def make_entry(run_lbl, variable, unit, data):
         '''
@@ -314,7 +307,6 @@ class DataLibrary:
             to be packaged into a data dictionary. Alternatively, this
             function can directly read in an ALARA output file and parse all
             tables and their metadata internally.
-
         Arguments:
             cls (alara_output_processing.DataLibrary)
             runs_dict (dict): ALARA output data. If parsing directly from
@@ -339,7 +331,7 @@ class DataLibrary:
                                     unit)
                 }
         '''
-        
+
         dfs = {}
         for run_lbl, output_path in runs_dict.items():
             parser = FileParser(output_path)
@@ -350,7 +342,7 @@ class DataLibrary:
                 dfs.update(
                     cls.make_entry(run_lbl, variable, unit.strip(']'), data)
                 )
-        
+
         return dfs
 
 ###########################################

--- a/tools/pyproject.toml
+++ b/tools/pyproject.toml
@@ -1,0 +1,46 @@
+[project]
+name = "alara-output-processing"
+description = "Postprocessing tools for ALARA simulation results"
+version = "0.0.1"
+readme = "README.md"
+license = {file="LICENSE.md"}
+requires-python = ">=3.8"
+
+maintainers = [
+    {name = "Eitan Weinstein", email = "esweinstein2@wisc.edu"},
+    {name = "Paul Wilson", email = "paul.wilson@wisc.edu"}
+]
+
+authors = [
+    {name = "Eitan Weinstein"},
+    {name = "Paul Wilson"}
+]
+
+keywords = ["fusion", "activation", "data", "simulation"]
+
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Science/Research",
+    "Programming Language :: Python :: 3",
+    "Topic :: Scientific/Engineering :: Physics",
+    "Topic :: Scientific/Engineering"
+]
+
+dependencies = [
+    "pandas"
+]
+
+[project.urls]
+Repository = "https://github.com/svalinn/ALARA/tree/main/tools/"
+Issues = "https://github.com/svalinn/ALARA/issues"
+
+[project.scripts]
+alara-output-processing = "alara_output_processing.alara_output_processing:main"
+
+[tool.setuptools.packages.find]
+include = ["alara_output_processing*"]
+exclude = ["jALARA*", "ALARAJOYWrapper*"]
+
+[build-system]
+requires = ["setuptools>=64.0.0"]
+build-backend = "setuptools.build_meta"


### PR DESCRIPTION
Closes #152 .

Allows the Python script `alara_output_processing.py` to be `pip` installable by creating a `pyproject.toml`, `README.md`, `LICENSE.md`, and a new subdirectory within `tools/`, `tools/alara_output_processing/`, containing `__init__.py` and moving `alara_output_processing.py`.