### PR TITLE
Fixing alara_output_processing pip installation guidelines

### DIFF
--- a/tools/README.md
+++ b/tools/README.md
@@ -12,8 +12,9 @@ Contained within `ALARA/tools` is the Python package, `alara_output_processing`,
 
 
 ## Installation
+From the directory `ALARA/tools/` run the following command to install `alara_output_processing`:
 ```
-pip install alara_output_processing
+pip install .
 ```
 
 ## Usage


### PR DESCRIPTION
This PR modifies the installation instructions for `alara_output_processing` to more successfully guide users to be able to `pip` install the module from the `ALARA/tools` directory.