### PR TITLE
Change alara_output_processing.py to add colons as separator

### DIFF
--- a/tools/alara_output_processing/alara_output_processing.py
+++ b/tools/alara_output_processing/alara_output_processing.py
@@ -3,7 +3,6 @@ import argparse
 from warnings import warn
 from csv import DictReader
 from numpy import array
-import re
 
 # ---------- General Utility Methods ----------
 
@@ -216,9 +215,8 @@ class FileParser:
         converted_times = extract_time_vals(
             times_w_units, to_unit=self.time_unit
         )
-
-        parts = [part for part in re.split(r"[ #:]", current_block) if part]
-        block_name, block_num_trail = parts[:2]
+        block_name, block_num_trail = current_block.split(' #')
+        block_num_trail = block_num_trail.split(':')[0]
         variable, unit = current_parameter.split(' [')
         
         reader = DictReader(


### PR DESCRIPTION
Currently, `parse_table_data()` in alara_output_processing.py uses ` #` as a separator to identify the block type and block number. However, if the block type is a zone, there is a colon at the end of the zone number. This would require the user to specify block_num as `1:`, for example, when filtering output data with the alara_output_processing module. This PR introduces a change intended to prevent the colon from being a necessary addition to the value of block_num.    