### PR TITLE
Option to Avoid Ground State Isomer Decay Assumption

### DIFF
--- a/tools/ALARAJOYWrapper/README.md
+++ b/tools/ALARAJOYWrapper/README.md
@@ -32,18 +32,13 @@ ALARAJOYWrapper is designed to produce a space-delimited DSV containing data tha
 To run this preprocessor, the user must first have acquired TENDL files for each isotope to be processed from [TENDL 2017](https://tendl.web.psi.ch/tendl_2017/tendl2017.html), which is the source for FENDL3.2x neutron activation data. All TENDL files to be processed must be in the same directory as each other to be properly identified by ALARAJOYWrapper.
 
 Running ALARAJOYWrapper can be done with one Python command:
-
-    python preprocess_fendl3.py -g gas_handling_method -f /path/to/fendl3_data_dir/ -d /path/to/eaf_decay_library/ -a
-
-This command takes five arguments,`-g `, `-f`, `-d`, `-i`, and `-a`. Of these, `-g`, `-f`, and `-d` are required. The `-g` argument sets the gas handling method for gas totals, as calculated by the NJOY GASPR module. The two possible methods are `r` (remove) and `s` (subtract). Method `r` removes all reactions with a light gas daughter (protons through alpha particles), with the exception of total gas production cross-sections corresponding to MT = 203-207 reactions (see Appendix B of the ENDF-6 Manual at `../../developer-info/endf6-manual.pdf`) when a total gas production cross-section exists. Method `s` subtracts the cross-sections for each energy group of reactions that produce a gas daughter from the total gas production cross-sections instead. In effect, for gas producing reactions, selecting `r` will show only the *total* gas production cross sections for each gas, whereas `s` will show each *individual* gas production pathway with its respective cross section data.
-
-The `-f` argument directs the program to the directory containing the TENDL files. This argument is optional, and if left blank, will default to the current working directory.
-
-The `-d` argument directs the program to an EAF decay library necessary for cross-referencing short-lived isomeric daughters against known half-life data.'
-
-The `-i` argument is an optional flag to amalgamate all isomers lacking decay data to an "Other" daughter with a KZA isomer value of `*`, instead of forcing their decay to their respective ground states.
-
-The `-a` argument is an optional flag to amalgamate all like-daughter nuclides of a given parent into a single row of the resultant DSV file by adding the groupwise cross-section data for all reaction pathways that produce said daughter from each parent.
+```
+python preprocess_fendl3.py -g gas_handling_method -f /path/to/fendl3_data_dir/ -d /path/to/eaf_decay_library/ -i -a
+```
+To read in detail about each of these arguments, call this command:
+```
+python preprocess_fendl3.py -h
+```
 
 
 ## Data Output
@@ -65,7 +60,7 @@ Running `preprocess_fendl3.py` will return the file path to the resultant space-
 - Non-Zero Groups: Count of total number of energy groups in the Vitamin-J 175 energy group structure with non-zero neutron cross sections.
 - Cross Sections: List of all non-zero neutron cross sections.
 
-It should be noted that TENDL 2017 activation data contains many (n,n) reactions that leave the residual nucleus in various quantized excited states, potentially up to a 40<sup>th</sup> excited state. Most of these daughter isomers, however, are extremely short-lived and lack decay data. When converting an ALARAJOY DSV file in ALARA, as discussed below, an EAF decay library is required, given that FENDL3.2x only contains activation data. Cross-referencing exotic isomers against this decay data ensures that ultra-short-lived reaction products are not passed on to ALARA's library conversion appearing as stable nuclides. Rather, the lack of decay data signifies such a short half-life that decay evaluations are not practical. As such, as these isomers are processed, ALARAJOYWrapper defaults to assume that they decay to the ground state and their cross-sections are accumulated for the ground state (n,n) reaction (MT = 4). To avoid making this assumption and instead to accumulate all of these reactions for each parent into an "Other" row, use the optional flag `-i` when running ALARAJOYWrapper (see above.)
+It should be noted that TENDL 2017 activation data contains many (n,n) reactions that leave the residual nucleus in various quantized excited states, potentially up to a 40<sup>th</sup> excited state. Most of these daughter isomers, however, are extremely short-lived and lack decay data. When converting an ALARAJOY DSV file in ALARA, as discussed below, an EAF decay library is required, given that FENDL3.2x only contains activation data. Cross-referencing exotic isomers against this decay data ensures that ultra-short-lived reaction products are not passed on to ALARA's library conversion appearing as stable nuclides. Rather, the lack of decay data signifies such a short half-life that decay evaluations are not practical. As such, as these isomers are processed, ALARAJOYWrapper defaults to assume that they decay to the ground state and their cross-sections are accumulated for the ground state (n,n) reaction (MT = 4). To avoid making this assumption and instead to accumulate all of these reactions for each parent into an "Other" row, use the optional flag `-i` when running ALARAJOYWrapper (see command-line argument `--help` or `-h` for more details).
 
 ## Application of Processed Data to ALARA Data Conversion Methods
 Data library conversion to ALARA binary libraries is done with the `convert_lib` input block in the ALARA input file. Converting preprocessed TENDL data contained in the resultant space-delimited DSV from ALARAJOYWrapper is done as such in the input file:

--- a/tools/ALARAJOYWrapper/preprocess_fendl3.py
+++ b/tools/ALARAJOYWrapper/preprocess_fendl3.py
@@ -11,19 +11,58 @@ from collections import defaultdict
 def args():
     parser = argparse.ArgumentParser()
     parser.add_argument(
-        '--fendlFileDir', '-f', required=False, nargs=1
+        '--gas_handling', '-g', required=True, nargs=1,
+        help=('''
+            Required argument to set the gas handling method for gas
+                production totals, as calculated by the NJOY GASPR module. The
+                two possible methods are "r" (remove) and "s" (subtract).
+                Method "r" removes all reactions with a light gas daughter
+                (protons through alpha particles), with the exception of total
+                gas production cross-sections corresponding to MT = 203-207
+                reactions (see Appendix B of the ENDF-6 Manual at 
+                ALARA/developer-info/endf6-manual.pdf) when a total gas
+                production cross-section exists. Method "s" subtracts the
+                cross-sections for each energy group of reactions that produce
+                a gas daughter from the total gas production cross-sections
+                instead. In effect, for gas producing reactions, selecting "r"
+                will show only the total gas production cross-sections for
+                each gas, whereas "s" will show each individual gas production
+                pathway with its respective cross-section data.
+        ''')
     )
     parser.add_argument(
-        '--gas_handling', '-g', required=True, nargs=1
+        '--decay_lib', '-d', required=True, nargs=1,
+        help=('''
+            Required argument to direct ALARAJOYWrapper to an EAF decay
+                library necessary for cross-referencing short-lived isomeric
+                daughters against known half-life data.
+        ''')
     )
     parser.add_argument(
-        '--decay_lib', '-d', required=True, nargs=1
+        '--fendlFileDir', '-f', required=False, nargs=1,
+        help=('''
+            Optional argument to direct ALARAJOYWrapper to the directory
+                containing the TENDL files to be processed. If left blank,
+                --fendlFileDir will default to the current working directory.
+        ''')
+              
     )
     parser.add_argument(
-        '--isomer_to_ground', '-i', action='store_false'
+        '--isomer_to_ground', '-i', action='store_false',
+        help=('''
+            Optional argument to amalgamate all isomers lackign decay data to
+                an "Other" daughter with a KZA isomer value of "*", instead of
+                forcing their decay to their respective ground states.
+        ''')
     )
     parser.add_argument(
-        '--amalgamate', '-a', action='store_true'
+        '--amalgamate', '-a', action='store_true',
+        help=('''
+            Optional argument to amalgamate all like-daughters of a given
+                parent into a single row of the resultant DSV file file by
+                adding the groupwise cross-section data for all reaction
+                pathways that produce said daughter from each parent.
+        ''')
     )
     parser.add_argument(
         # Temperature for NJOY run [Kelvin]

--- a/tools/ALARAJOYWrapper/tendl_processing.py
+++ b/tools/ALARAJOYWrapper/tendl_processing.py
@@ -284,13 +284,15 @@ def iterate_MTs(MTs, file_obj, mt_dict, pKZA, all_rxns, radionucs, to_ground):
         # (n,n) reaction's cross-sections or to a new psuedo-daughter of all
         # isomers with undefined decays for that parent
         else:
-            composite_KZA = f'{pKZA // 10}*'
-            special_MT, decay_KZA = (
-                (-4, pKZA) if to_ground else (-1, composite_KZA)
-            )
-
-            if not to_ground and composite_KZA not in all_rxns[pKZA]:
-                all_rxns[pKZA][composite_KZA] = defaultdict(dict)
+            if to_ground:
+                decay_KZA = f'{pKZA // 10}*'
+                special_MT = -1
+                if decay_KZA not in all_rxns[pKZA]:
+                    all_rxns[pKZA][decay_KZA] = defaultdict(dict)
+            
+            else:
+                decay_KZA = pKZA
+                special_MT = -4
 
             if special_MT not in all_rxns[pKZA][decay_KZA]:
                 all_rxns[pKZA][decay_KZA][special_MT] = {


### PR DESCRIPTION
Closes #212.

This PR introduces an optional alternate pathway to avoid making the physics assumption that all ultra-short-lived isomers lacking known half-lives will necessarily decay to their ground states. Rather, the methods introduced in this PR create a new reaction row with a pseudo-daughter for all of these excitation reactions signified with a `*` as the KZA isomer tag (i.e. `26054*` for all relevant (n,n) excitation reactions for <sup>54</sup>Fe). All of these cross-sections are accumulated to this row instead of the ground state.