### PR TITLE
ALARADFrame Half-Life Filtering

### DIFF
--- a/src/Result.C
+++ b/src/Result.C
@@ -469,7 +469,7 @@ void Result::write(int response, int targetKza, Mixture *mixPtr,
         sprintf(isoSym, "%-11.4e ", thalf);
         cout << isoSym;
       } else {
-        cout << "stable      ";
+        cout << "-1          ";
       }
  
      for (resNum=0;resNum<nResults;resNum++)
@@ -503,7 +503,7 @@ void Result::write(int response, int targetKza, Mixture *mixPtr,
   coolList->writeSeparator();
 
   /* write the formatted output for the total response */
-  cout << "total   None        ";
+  cout << "total   0           ";
   
   for (resNum=0;resNum<nResults;resNum++)
     {

--- a/tools/README.md
+++ b/tools/README.md
@@ -50,6 +50,7 @@ The columns for `adfs` are:
 * `time`: Cooling time in seconds.
 * `time_unit`: Units for cooling time.
 * `nuclide`: Nuclide name formatted as "element-A" (i.e. "h-1" for <sup>1</sup>H) or "total".
+* `half_life`: Half-life in seconds of an unstable nuclide. `-1` for stable nuclides, `0` for "total" rows.
 * `run_lbl`: Distinguisher between runs (i.e. "run1", "run2", etc.).
 * `block`: Integer enumerator for the geometric block key name. Possible block keys are "Interval", "Material", or "Zone", and their enumerator values can be accessed through `ALARADFrame().BLOCK_ENUM[block]`, where `block` is one of the above keys.
 * `block_num`: Geometric position of the block.
@@ -69,13 +70,13 @@ The columns for `adfs` are:
 Below is the example `head()` of an `ALARADFrame`:
 
 
-| | time | time_unit | nuclide | run_lbl | block | block_num | variable | var_unit | value |
-|-|------|-----------|---------|---------|-------|-----------|----------|----------|-------|
-| 0 | 's' | 0.000000e+00 | h-1 | fendl2 | 0 | 1 | 0 | atoms/kg | 1.176100e+22
-| 1 | 's' | 3.153600e+02 | h-1 | fendl2 | 0 | 1 | 0 | atoms/kg | 1.176100e+22
-| 2 | 's' | 3.153600e+05 | h-1 | fendl2 | 0 | 1 | 0 | atoms/kg | 1.176100e+22
-| 3 | 's' | 3.153600e+07 | h-1 | fendl2 | 0 | 1 | 0 | atoms/kg | 1.176100e+22
-| 4 | 's' | 3.153600e+09 | h-1 | fendl2 | 0 | 1 | 0 | atoms/kg | 1.176100e+22
+||time|time_unit|nuclide|half_life|run_lbl|block|block_num|variable| var_unit|value|
+|-|-|-|-|-|-|-|-|-|-|-|
+| 0 | 's' | 0.000000e+00 | h-1 | -1 | fendl2 | 0 | 1 | 0 | atoms/kg | 1.176100e+22
+| 1 | 's' | 3.153600e+02 | h-1 | -1 | fendl2 | 0 | 1 | 0 | atoms/kg | 1.176100e+22
+| 2 | 's' | 3.153600e+05 | h-1 | -1 | fendl2 | 0 | 1 | 0 | atoms/kg | 1.176100e+22
+| 3 | 's' | 3.153600e+07 | h-1 | -1 | fendl2 | 0 | 1 | 0 | atoms/kg | 1.176100e+22
+| 4 | 's' | 3.153600e+09 | h-1 | -1 | fendl2 | 0 | 1 | 0 | atoms/kg | 1.176100e+22
 
 The five rows in the head correspond to the number density of <sup>1</sup>H in the 1st interval of a run of FENDL2 data with four cooling times.
 
@@ -94,7 +95,7 @@ The parameter `filter_dict` allows filtering over any number of columns and any 
 
 When filtering the `nuclide` column, `ALARADFrame.filter_rows()` has functionality to select all nuclides of a particular element, as well as selecting individual nuclides. To do so, instead of  `filter_dict["nuclide"] = "fe-55"`, write `filter_dict["nuclide"] = "fe"` to filter all iron isotopes, instead of just <sup>55</sup>Fe, for example. Similarly, multiple whole elements can be selected by inputting them as a list for `filter_dict["nuclide"]`. It is also possible to filter by a combination of whole elements and individual nuclides.
 
-Additional filtering can be done on the stability of nuclides. To filter all stable nuclides, write `filter_dict["half_lives] = "stable"`. To filter all unstable nuclides, write `filter_dict["half_lives] = "unstable"` or `filter_dict["half_lives] = "radioactive". ` Half-life filtering can also be done relative to certain time thresholds, such as filtering all nuclides with half-lives greater than 1e6 seconds. To do so write `filter_dict["half_lives] = ['>', 1e6]`. Generally, the format for this time-operator filtering is `filter_dict["half_lives] = [{operator}, {threshold}]`. 
+Additional filtering can be done on the stability of nuclides. To filter all stable nuclides, write `filter_dict["half_lives] = "stable"` or `filter_dict["half_lives] = -1`. To filter all unstable nuclides, write `filter_dict["half_lives] = "unstable"` or `filter_dict["half_lives] = "radioactive". ` Half-life filtering can also be done relative to certain time thresholds, such as filtering all nuclides with half-lives greater than 1e6 seconds. To do so write `filter_dict["half_lives] = ['>', 1e6]`. Generally, the format for this time-operator filtering is `filter_dict["half_lives] = [{operator}, {threshold}]`. 
 
 Below is an example filtering operation on the same `adf` from the above example:
 ```
@@ -106,19 +107,19 @@ fendl2_spec_act_h3 = adf.filter_rows({
 ```
 The `head()` of `fendl2_spec_act_h3` is:
 
-| | time | time_unit | nuclide | run_lbl | block | block_num | variable | var_unit | value |
-|-|------|-----------|---------|---------|-------|-----------|----------|----------|-------|
-| 0 | 's' | 0.000000e+00 | h-3 | fendl2 | 0 | 1 | 1 | Bq/kg | 1.988300e+09
-| 1 | 's' | 3.153600e+02 | h-3 | fendl2 | 0 | 1 | 1 | Bq/kg | 1.988300e+09
-| 2 | 's' | 3.153600e+05 | h-3 | fendl2 | 0 | 1 | 1 | Bq/kg | 1.987100e+09
-| 3 | 's' | 3.153600e+07 | h-3 | fendl2 | 0 | 1 | 1 | Bq/kg | 1.879900e+09
-| 4 | 's' | 3.153600e+09 | h-3 | fendl2 | 0 | 1 | 1 | Bq/kg | 7.334700e+06
+||time|time_unit|nuclide|half_life|run_lbl|block|block_num|variable| var_unit|value|
+|-|-|-|-|-|-|-|-|-|-|-|
+| 0 | 's' | 0.000000e+00 | h-3 | 3.880000e+08 | fendl2 | 0 | 1 | 1 | Bq/kg | 1.988300e+09
+| 1 | 's' | 3.153600e+02 | h-3 | 3.880000e+08 | fendl2 | 0 | 1 | 1 | Bq/kg | 1.988300e+09
+| 2 | 's' | 3.153600e+05 | h-3 | 3.880000e+08 | fendl2 | 0 | 1 | 1 | Bq/kg | 1.987100e+09
+| 3 | 's' | 3.153600e+07 | h-3 | 3.880000e+08 | fendl2 | 0 | 1 | 1 | Bq/kg | 1.879900e+09
+| 4 | 's' | 3.153600e+09 | h-3 | 3.880000e+08 | fendl2 | 0 | 1 | 1 | Bq/kg | 7.334700e+06
 
 Once data has been filtered, it can be useful to create a pivot table using `pandas.DataFrame.pivot()` to reorganize data by `nuclide` vs `time`. An example filtering and pivot table sequence (without nuclide filtering to show multiple multiple rows) is as such:
 ```
 filtered_adf = adf.filter_rows({
     "run_lbl" : "fendl2",
-    "variable" : adf.VARAIBLE_ENUM["Specific Activity"]
+    "variable" : adf.VARIABLE_ENUM["Specific Activity"]
 })
 pivot_df = filtered_adf.pivot(
     index="nuclide",


### PR DESCRIPTION
Closes #216.
Closes #203.
Closes #202 .

This PR follows the inclusion of half-lives into the canonical structure of ALARADFrames in #206. I've introduced filtering capabilities in `alara_output_processing.filter_rows()` for users to filter on the stability or lack thereof of the nuclides in the ALARADFrame, as well as filtering half-lives against time thresholds (i.e. preserving all nuclides with a half-live greater than 1e6 seconds).
