### PR TITLE
Adding missing return line in rxn_to_str()

### DIFF
--- a/tools/ALARAJOYWrapper/preprocess_fendl3.py
+++ b/tools/ALARAJOYWrapper/preprocess_fendl3.py
@@ -231,7 +231,7 @@ def write_dsv(dsv_path, all_rxns):
 
     with open(dsv_path, 'w') as dsv:
         dsv.write(str(tp.VITAMIN_J_ENERGY_GROUPS) + '\n')
-        for parent in all_rxns:
+        for parent in sorted(all_rxns):
             for daughter in all_rxns[parent]:
                 for rxn in all_rxns[parent][daughter].values():
                     if rxn['xsections'].sum() > 0:


### PR DESCRIPTION
I realized that the new function `rxn_to_str()` in `preprocess_fendl3.py` was missing its return line, so the DSV writing was failing (unfortunately only _after_ trying to go through a full run with FENDL3!).