### PR TITLE
Add machine-readable output to ScheduleItem.C

### DIFF
--- a/src/Schedule.C
+++ b/src/Schedule.C
@@ -202,9 +202,8 @@ void Schedule::write(int level, char *histName, double delay, char dUnits)
     {
       for (lvlNum=0;lvlNum<level;lvlNum++)
 	cout << "\t";
-      cout << "Schedule '" << ptr->schedName << "' with " << delay 
-	   << " " << dUnits << " delay and pulsed with history '" 
-	   << histName << "':" << endl;
+      cout << "schedule " << ptr->schedName << " pulse_history " << histName 
+	   << " delay " << delay << " " << dUnits << " " << endl; 
     }
 
   ptr->itemListHead->write(level+1);

--- a/src/ScheduleItem.C
+++ b/src/ScheduleItem.C
@@ -211,11 +211,6 @@ void ScheduleItem::write(int level)
       switch (ptr->type)
 	{
 	case SCHED_PULSE: /* single pulse */
-	  for (lvlNum=0;lvlNum<level;lvlNum++)
-	    cout << "\t";
-	  cout << "pulse: " << ptr->opTime << " " << ptr->opUnits 
-	       << " with " << ptr->delay << " " << ptr->dUnits 
-	       << " delay pulsed with history "  << ptr->hist->getName() << endl;
     for (lvlNum=0; lvlNum<level; lvlNum++)
       cout << "\t";     
 	  cout << "pulse_entry: " << ptr->opTime << " " << ptr->opUnits 


### PR DESCRIPTION
A new entry has been added to `ScheduleItem.C` to print the entries of each schedule item in a format that is more succinct and machine readable, along with the original human-readable format. The components of the new string are in the order:

`pulse_entry: <pulse duration> <pulse duration units> pulse_history <pulse history name> delay <delay duration> <delay duration units>`

This change only affects the individual pulse entries and not the schedule-level entries created in `Schedule.C`.
fixes #219 