### PR TITLE
Updating reaction_data.py EAF parsing to handle separate nuclide decay files

### DIFF
--- a/tools/ALARAJOYWrapper/preprocess_fendl3.py
+++ b/tools/ALARAJOYWrapper/preprocess_fendl3.py
@@ -34,8 +34,12 @@ def args():
         '--decay_lib', '-d', required=True, nargs=1,
         help=('''
             Required argument to direct ALARAJOYWrapper to an EAF decay
-                library necessary for cross-referencing short-lived isomeric
-                daughters against known half-life data.
+                library or directory containing EAF decay files for
+                individual nuclides. Necessary for cross-referencing short-
+                lived isomeric daughters against known half-life data.
+              
+                Note: If using --decay_lib to direct to a directory of EAF
+                decay files, all files must have the extension ".dat".
         ''')
     )
     parser.add_argument(


### PR DESCRIPTION
For ALARAJOYWrapper, which requires a reference EAF decay file to identify radionuclides, this PR expands that functionality to allow for many distinct EAF decay files all stored within the same directory to be called as well. The motivation for this was in expanding the available EAF reference to more easily incorporate different EAF libraries with minimal user preparation. As far as I could find, [EAF2010 decay data](https://nds.iaea.org/fendl20/fen-decay.htm) is only available as separate `.gz` files of grouped nuclides and [UKDD12](https://nds.iaea.org/public/download-endf/UKDD-12/decay/), which is the standard EAF-formatted, FISPACT-II decay library, is available only as individual `.zip` files for each nuclide in the decay library. With this PR, regardless of EAF-formatted decay library the user chooses, they only need to download the files in a single directory, unzip them, and ensure that they have the extension `.dat`.