### PR TITLE
Minor adjustments to ALARA output processing

### DIFF
--- a/tools/alara_output_processing/alara_output_plotting.py
+++ b/tools/alara_output_processing/alara_output_plotting.py
@@ -627,7 +627,7 @@ def single_time_pie_chart(
         else f' at {times[time_idx]} {time_unit}'
     )
     ax.set_title(
-        f'{run_lbl}: Aggregated Proportional Contitributions to ' \
+        f'{run_lbl}:\nAggregated Proportional Contitributions to ' \
         f'{variable}{header_time}',
         loc='right'
     )

--- a/tools/alara_output_processing/alara_output_processing.py
+++ b/tools/alara_output_processing/alara_output_processing.py
@@ -667,21 +667,15 @@ class ALARADFrame(pd.DataFrame):
         adf_rel['var_unit'] = [None] * len(adf_rel)
 
         return adf_rel
-
-    #### FISPACT-II Hybrid ALARADFrame Operations ####
-    ####    (ALARADFrames with FISPACT-II data)   ####
-
+    
     def create_total_rows(self):
         '''
         Calculate and insert "total" nuclide row data for each variable,
-            time-step in an ALARADFrame. Only used when loading FISPACT-II
-            output data into an ALARADFrame, as ALARA output data always
-            contains cumulative "total" data at each time-step.
+            time-step in an ALARADFrame.
 
         Arguments:
             self (alara_output_processing.ALARADFrame): Specialized DataFrame
-                for ALARA output data, containing FISPACT-II output data as
-                well.
+                for ALARA output data.
 
         Returns:
             adf_with_totals (alara_output_processing.ALARADFrame): Updated
@@ -703,6 +697,9 @@ class ALARADFrame(pd.DataFrame):
         totals['half_life'] = 0
 
         return pd.concat([self, totals], ignore_index=True)
+
+    #### FISPACT-II Hybrid ALARADFrame Operations ####
+    ####    (ALARADFrames with FISPACT-II data)   ####
 
     def fill_skipped_nucs(self, all_nucs):
         '''


### PR DESCRIPTION
As I've been working through the benchmarking of single-element irradiations, I've noticed a few useful changes in the processing/plotting tools for ALARA that I've included together in this PR:

* Reclassifying `alara_output_processing.ALARADFrame.create_total_rows()` from being used only for FISPACT-II ALARADFrames because I realized that this function is also necessary when plotting pie charts of only-transmutation products, which otherwise filter out the `total` row, so a new one needs to be created.
* Adding in line-break in pie chart titles