### PR TITLE
Excluding "effectively elastic" neutron scattering reactions

### DIFF
--- a/tools/ALARAJOYWrapper/preprocess_fendl3.py
+++ b/tools/ALARAJOYWrapper/preprocess_fendl3.py
@@ -280,10 +280,10 @@ def write_dsv(dsv_path, all_rxns):
         dsv.write(str(tp.VITAMIN_J_ENERGY_GROUPS) + '\n')
         for parent in sorted(all_rxns):
             for daughter in all_rxns[parent]:
-                for rxn in all_rxns[parent][daughter].values():
-                    if rxn['xsections'].sum() > 0:
-                        dsv.write(rxn_to_str(parent, daughter, rxn) + '\n')
-        
+                if parent != daughter:
+                    for rxn in all_rxns[parent][daughter].values():
+                        if rxn['xsections'].sum() > 0:
+                            dsv.write(f'{rxn_to_str(parent,daughter,rxn)}\n')
         # End of File (EOF) signifier to be read by ALARAJOY
         dsv.write(str(-1))
 


### PR DESCRIPTION
Independent of #229.

This PR prevents the writing of reactions in which the parent and daughter are the same out to the DSV for ALARAJOYWrapper. As it stands, MT = 2 (elastic neutron scattering) is already excluded, but because we have processing to force isomers lacking decay data to ground, those reactions are effectively creating new pathways for elastic scattering. To reduce the size of the processed DSV file (and subsequent tree files), these reactions can be excluded entirely.  