### PR TITLE
Small Updates to alara_output_plotting

### DIFF
--- a/tools/alara_output_processing/alara_output_plotting.py
+++ b/tools/alara_output_processing/alara_output_plotting.py
@@ -124,7 +124,7 @@ def build_color_map(cmap_name, all_nucs=[], pivs=None):
     }
 
     if 'Other' in set(all_nucs):
-        color_map['Other'] = (0.3, 0.3, 0.3, 1.0)
+        color_map['Other'] = (0.8, 0.8, 0.8, 1.0)
 
     return color_map
 
@@ -355,12 +355,9 @@ def pie_grid_relative_tables(
         loc='center',
         cellLoc='center'
     )
-    for (row, col), cell in table.get_celld().items():
-        if row > 1:
-            cell.get_text().set_color('whitesmoke')
 
     table.auto_set_font_size(False)
-    table.set_fontsize(11)
+    table.set_fontsize(14)
     table.scale(1.0, 2.0)
 
     # Format table for readability


### PR DESCRIPTION
As I've been going through looking at the longer term activation responses for the ALARAJOY-processed FENDL3 data and comparing it with FISPACT-II data, there have been a number of small changes that I've found beneficial to include into the ALARA output plotting module:

- Allowing the user to choose between plotting with `plt.plot()` or `plt.scatter()` when calling `plot_single_response()`
- Creating an option for a minimum y-axis cutoff (I'm seeing that responses will be going down to exceedingly small values (E-32) which is both beyond any actual meaningful precision and extends the plots to unnecessary large vertical ranges).
- Including the absolute total values in the `multi_time_pie_grid()` tables to contextualize the proportional nuclide data in the rest of the table and in the grid of pie charts.