### PR TITLE
Flagging Invalid MTs from Corrupted TENDL Files

### DIFF
--- a/tools/ALARAJOYWrapper/preprocess_fendl3.py
+++ b/tools/ALARAJOYWrapper/preprocess_fendl3.py
@@ -507,7 +507,7 @@ def main():
         endf_path = file_properties['TENDL File Path']
         TAPE20.write_bytes(endf_path.read_bytes())
 
-        material_id, MTs, endftk_file_obj = tp.extract_endf_specs(TAPE20)
+        material_id, MTs = tp.extract_endf_specs(TAPE20)
         endf6_MTs = set(mt_dict.keys())
         if len(MTs - endf6_MTs) > 0:
             invalid_MTs = sorted(MTs - endf6_MTs)


### PR DESCRIPTION
Closes #252.

In the event that a user supplies a TENDL file containing reaction types not listed in Appendix B of the ENDF-6 Manual, provide a warning system so that the corrupted file(s) can be replaced.