### PR TITLE
Addition to MT warning system to avoid warning for MTs that are automatically filtered

### DIFF
--- a/tools/ALARAJOYWrapper/preprocess_fendl3.py
+++ b/tools/ALARAJOYWrapper/preprocess_fendl3.py
@@ -9,18 +9,6 @@ from pathlib import Path
 from collections import defaultdict
 
 ISOMERIC_STATES = 'mnopqrstuvwxyz'
-PREFILTERED_MTS = {
-    1,  # (n, total)
-    2,  # (z,z0)
-    3,  # (z, nonelas.)
-    5,  # (z, anything)
-    18, # (z, fission)
-    19, # (n,f)
-    20, # (n,nf)
-    21, # (n,2nf)
-    38  # (n,3nf)
-}
-
 
 def args():
     parser = argparse.ArgumentParser()
@@ -418,7 +406,7 @@ def main():
         TAPE20.write_bytes(endf_path.read_bytes())
 
         material_id, MTs = tp.extract_endf_specs(TAPE20)
-        endf6_MTs = set(mt_dict.keys())
+        endf6_MTs = set(mt_dict)
         if len((MTs - rxd.SPEC_MTS) - endf6_MTs) > 0:
             invalid_MTs = sorted((MTs - rxd.SPEC_MTS) - endf6_MTs)
             warnings.warn(

--- a/tools/ALARAJOYWrapper/preprocess_fendl3.py
+++ b/tools/ALARAJOYWrapper/preprocess_fendl3.py
@@ -9,6 +9,18 @@ from pathlib import Path
 from collections import defaultdict
 
 ISOMERIC_STATES = 'mnopqrstuvwxyz'
+PREFILTERED_MTS = {
+    1,  # (n, total)
+    2,  # (z,z0)
+    3,  # (z, nonelas.)
+    5,  # (z, anything)
+    18, # (z, fission)
+    19, # (n,f)
+    20, # (n,nf)
+    21, # (n,2nf)
+    38  # (n,3nf)
+}
+
 
 def args():
     parser = argparse.ArgumentParser()
@@ -406,12 +418,11 @@ def main():
         TAPE20.write_bytes(endf_path.read_bytes())
 
         material_id, MTs = tp.extract_endf_specs(TAPE20)
-        pre_filtered_MTs = {1,2,3,5}
-        endf6_MTs = set(mt_dict.keys()) - pre_filtered_MTs
-        if len(MTs - endf6_MTs) > 0:
-            invalid_MTs = sorted(MTs - endf6_MTs)
+        endf6_MTs = set(mt_dict.keys()) - PREFILTERED_MTS
+        if len((MTs - PREFILTERED_MTS) - endf6_MTs) > 0:
+            invalid_MTs = sorted((MTs - PREFILTERED_MTS) - endf6_MTs)
             warnings.warn(
-                f'Invalid MTs in provided TENDL file for' \
+                f'Invalid MTs in provided TENDL file for ' \
                 f'{element}-{A}: {invalid_MTs}'
             )
         MTs = MTs.intersection(endf6_MTs)

--- a/tools/ALARAJOYWrapper/preprocess_fendl3.py
+++ b/tools/ALARAJOYWrapper/preprocess_fendl3.py
@@ -418,9 +418,9 @@ def main():
         TAPE20.write_bytes(endf_path.read_bytes())
 
         material_id, MTs = tp.extract_endf_specs(TAPE20)
-        endf6_MTs = set(mt_dict.keys()) - PREFILTERED_MTS
-        if len((MTs - PREFILTERED_MTS) - endf6_MTs) > 0:
-            invalid_MTs = sorted((MTs - PREFILTERED_MTS) - endf6_MTs)
+        endf6_MTs = set(mt_dict.keys())
+        if len((MTs - rxd.SPEC_MTS) - endf6_MTs) > 0:
+            invalid_MTs = sorted((MTs - rxd.SPEC_MTS) - endf6_MTs)
             warnings.warn(
                 f'Invalid MTs in provided TENDL file for ' \
                 f'{element}-{A}: {invalid_MTs}'

--- a/tools/ALARAJOYWrapper/preprocess_fendl3.py
+++ b/tools/ALARAJOYWrapper/preprocess_fendl3.py
@@ -157,7 +157,7 @@ def process_pendf(
     pendf_path, njoy_error = njt.run_njoy(element, A, material_id, 'PENDF')
 
     _, pendf_MTs = tp.extract_endf_specs(pendf_path)
-    MTs |= set(pendf_MTs).intersection(set(rxd.GAS_DF['total_mt']))
+    MTs |= pendf_MTs.intersection(set(rxd.GAS_DF['total_mt']))
     isomer_dict = tp.determine_all_excitations(tendl_path, MTs, pKZA, mt_dict)
 
     return MTs, isomer_dict, njoy_error
@@ -406,14 +406,15 @@ def main():
         TAPE20.write_bytes(endf_path.read_bytes())
 
         material_id, MTs = tp.extract_endf_specs(TAPE20)
-        endf6_MTs = set(mt_dict.keys())
+        pre_filtered_MTs = {1,2,3,5}
+        endf6_MTs = set(mt_dict.keys()) - pre_filtered_MTs
         if len(MTs - endf6_MTs) > 0:
             invalid_MTs = sorted(MTs - endf6_MTs)
             warnings.warn(
                 f'Invalid MTs in provided TENDL file for' \
                 f'{element}-{A}: {invalid_MTs}'
             )
-        MTs = set(MTs).intersection(endf6_MTs)
+        MTs = MTs.intersection(endf6_MTs)
 
         MTs, isomer_dict, njoy_prep_error = process_pendf(
             njt.njoy_prep_input, material_id, MTs,

--- a/tools/ALARAJOYWrapper/reaction_data.py
+++ b/tools/ALARAJOYWrapper/reaction_data.py
@@ -220,36 +220,35 @@ def process_mt_data(mt_dict):
             }
     """
 
+    for MT in (set(mt_dict) & SPEC_MTS):
+        del mt_dict[MT]
+
     for MT, data in list(mt_dict.items()):
-        if MT in SPEC_MTS:
-            del mt_dict[MT]
+        emitted_particles = data['reaction'].split(',')[1][:-1]
+        emission_dict = emission_breakdown(emitted_particles)
+        change_NP = nucleon_changes(emission_dict)
+        M = check_for_isomer(emitted_particles)
+        emitted_list = list(emitted_particles)
+        gas = emitted_list[1] if (
+            emitted_list[0] == 'X' and emitted_list[1] in GASES
+        ) else None
 
+        # Conditionally remove isomer tags from emitted particle strings
+        if M > 0:
+            emitted_particles = emitted_particles[:-len(str(M))]
+
+        # Set gas total tag to standard ALARA tag for gas reaction residual
+        if 'X' in emitted_particles:
+            emitted_particles = 'x'
+        
+        if change_NP is not None:
+            change_N, change_P = change_NP
+            data['delKZA'] = (change_P * 1000 + change_P + change_N) * 10 + M
+            data['gas'] = gas
+            data['emitted'] = emitted_particles
+        
         else:
-            emitted_particles = data['reaction'].split(',')[1][:-1]
-            emission_dict = emission_breakdown(emitted_particles)
-            change_NP = nucleon_changes(emission_dict)
-            M = check_for_isomer(emitted_particles)
-            emitted_list = list(emitted_particles)
-            gas = emitted_list[1] if (
-                emitted_list[0] == 'X' and emitted_list[1] in GASES
-            ) else None
-
-            # Conditionally remove isomer tags from emitted particle strings
-            if M > 0:
-                emitted_particles = emitted_particles[:-len(str(M))]
-
-            # Set gas total tag to standard ALARA tag for gas reaction residual
-            if 'X' in emitted_particles:
-                emitted_particles = 'x'
-            
-            if change_NP is not None:
-                change_N, change_P = change_NP
-                data['delKZA'] = (change_P * 1000 + change_P + change_N) * 10 + M
-                data['gas'] = gas
-                data['emitted'] = emitted_particles
-            
-            else:
-                del mt_dict[MT]
+            del mt_dict[MT]
 
     return mt_dict
 

--- a/tools/ALARAJOYWrapper/reaction_data.py
+++ b/tools/ALARAJOYWrapper/reaction_data.py
@@ -28,6 +28,18 @@ spec_reactions = [
     'fission', 'f', 'RES', 'X', 'disap', 'abs'
     ]
 
+SPEC_MTS = {
+    1,  # (n, total)
+    2,  # (z,z0)
+    3,  # (z, nonelas.)
+    5,  # (z, anything)
+    18, # (z, fission)
+    19, # (n,f)
+    20, # (n,nf)
+    21, # (n,2nf)
+    38  # (n,3nf)
+}
+
 def count_emitted_particles(particle, emitted_particle_string):
     """
     Count emitted particles from a reaction given a target particle
@@ -209,30 +221,35 @@ def process_mt_data(mt_dict):
     """
 
     for MT, data in list(mt_dict.items()):
-        emitted_particles = data['reaction'].split(',')[1][:-1]
-        emission_dict = emission_breakdown(emitted_particles)
-        change_NP = nucleon_changes(emission_dict)
-        M = check_for_isomer(emitted_particles)
-        emitted_list = list(emitted_particles)
-        gas = emitted_list[1] if (
-            emitted_list[0] == 'X' and emitted_list[1] in GASES
-        ) else None
-
-        # Conditionally remove isomer tags from emitted particle strings
-        if M > 0:
-            emitted_particles = emitted_particles[:-len(str(M))]
-
-        # Set gas total tag to standard ALARA tag for gas reaction residual
-        if 'X' in emitted_particles:
-            emitted_particles = 'x'
-        
-        if change_NP is not None:
-            change_N, change_P = change_NP
-            data['delKZA'] = (change_P * 1000 + change_P + change_N) * 10 + M
-            data['gas'] = gas
-            data['emitted'] = emitted_particles
-        else:
+        if MT in SPEC_MTS:
             del mt_dict[MT]
+
+        else:
+            emitted_particles = data['reaction'].split(',')[1][:-1]
+            emission_dict = emission_breakdown(emitted_particles)
+            change_NP = nucleon_changes(emission_dict)
+            M = check_for_isomer(emitted_particles)
+            emitted_list = list(emitted_particles)
+            gas = emitted_list[1] if (
+                emitted_list[0] == 'X' and emitted_list[1] in GASES
+            ) else None
+
+            # Conditionally remove isomer tags from emitted particle strings
+            if M > 0:
+                emitted_particles = emitted_particles[:-len(str(M))]
+
+            # Set gas total tag to standard ALARA tag for gas reaction residual
+            if 'X' in emitted_particles:
+                emitted_particles = 'x'
+            
+            if change_NP is not None:
+                change_N, change_P = change_NP
+                data['delKZA'] = (change_P * 1000 + change_P + change_N) * 10 + M
+                data['gas'] = gas
+                data['emitted'] = emitted_particles
+            
+            else:
+                del mt_dict[MT]
 
     return mt_dict
 

--- a/tools/ALARAJOYWrapper/tendl_processing.py
+++ b/tools/ALARAJOYWrapper/tendl_processing.py
@@ -117,7 +117,7 @@ def extract_endf_specs(path):
     
     Returns:
         matb (int): Unique material ID extracted from the file.
-        MTs (list): List of reaction types (MT's) present in the file.
+        MTs (set): Set of reaction types (MT's) present in the file.
     """
 
     # Set MF for cross-sections
@@ -126,7 +126,7 @@ def extract_endf_specs(path):
     
     if file:
         # Extract the MT numbers that are present in the file
-        MTs = [MT.MT for MT in file.sections.to_list()]
+        MTs = set(MT.MT for MT in file.sections.to_list())
 
         return (matb, MTs)
     


### PR DESCRIPTION
Re-opening the PR for this branch because I noticed that the ENDF-6 MT reference warning was always flagging MTs 1,2,3, and 5, which are automatically filtered out in `tendl_processing`, so it is not usefully informative to be including a warning for this case.