### PR TITLE
Correctly identify the top schedule

### DIFF
--- a/src/Schedule.C
+++ b/src/Schedule.C
@@ -184,7 +184,6 @@ void Schedule::write(int level, char *histName, double delay, char dUnits)
   /* on first call, search for top level schedule */
   if (level==0)
     {
-      // bool found_top_sched = FALSE;
       verbose(0,"\n\n***Please review this schedule hierarchy.!!!!!!!!!!\n");
       Schedule *top_sched = NULL;
       while (ptr->next != NULL)
@@ -192,16 +191,12 @@ void Schedule::write(int level, char *histName, double delay, char dUnits)
 	  ptr = ptr->next;
 	  if (!ptr->usedAsSub)
     {
-      // if (found_top_sched)
-      //   error(400, "Multiple top schedules have been found. Only one schedule can be the top schedule.");
-      // found_top_sched = TRUE;
       top_sched = ptr;
       break;
     }
     
 	}    
       if (top_sched == NULL)
-      // if (found_top_sched == FALSE)
 	      error(400,"Unable to find top level schedule.\nA top level schedule must not used as a sub-schedule.");
 
       Schedule *next_sched = ptr;

--- a/src/Schedule.C
+++ b/src/Schedule.C
@@ -184,21 +184,34 @@ void Schedule::write(int level, char *histName, double delay, char dUnits)
   /* on first call, search for top level schedule */
   if (level==0)
     {
-      bool found_top_sched = FALSE;
+      // bool found_top_sched = FALSE;
       verbose(0,"\n\n***Please review this schedule hierarchy.!!!!!!!!!!\n");
+      Schedule *top_sched = NULL;
       while (ptr->next != NULL)
-	{
+  {
 	  ptr = ptr->next;
 	  if (!ptr->usedAsSub)
     {
-      if (found_top_sched)
-        error(400, "Multiple top schedules have been found. Only one schedule can be the top schedule.");
-      found_top_sched = TRUE;
-    }  
-	}
-      
-      if (found_top_sched == FALSE)
-	error(400,"Unable to find top level schedule.\nA top level schedule must not used as a sub-schedule.");
+      // if (found_top_sched)
+      //   error(400, "Multiple top schedules have been found. Only one schedule can be the top schedule.");
+      // found_top_sched = TRUE;
+      top_sched = ptr;
+      break;
+    }
+    
+	}    
+      if (top_sched == NULL)
+      // if (found_top_sched == FALSE)
+	      error(400,"Unable to find top level schedule.\nA top level schedule must not used as a sub-schedule.");
+
+      Schedule *next_sched = ptr;
+      while (next_sched != NULL)
+  {
+    if (!next_sched->usedAsSub && next_sched != top_sched)
+      error(400, "Multiple top schedules have been found. Only one schedule can be the top schedule.");
+
+    next_sched = next_sched->next;
+  }
 
       cout << "top_schedule '" << ptr->schedName << "':" << endl;
     }

--- a/src/Schedule.C
+++ b/src/Schedule.C
@@ -184,29 +184,27 @@ void Schedule::write(int level, char *histName, double delay, char dUnits)
   /* on first call, search for top level schedule */
   if (level==0)
     {
+      bool found_top_sched = FALSE;
       verbose(0,"\n\n***Please review this schedule hierarchy.!!!!!!!!!!\n");
-      Schedule *top_sched = NULL;
       while (ptr->next != NULL)
-  {
-	  ptr = ptr->next;
-	  if (!ptr->usedAsSub)
-    {
-      top_sched = ptr;
-      break;
-    }
-    
-	}    
-      if (top_sched == NULL)
-	      error(400,"Unable to find top level schedule.\nA top level schedule must not used as a sub-schedule.");
-
-      Schedule *next_sched = ptr;
-      while (next_sched != NULL)
-  {
-    if (!next_sched->usedAsSub && next_sched != top_sched)
-      error(400, "Multiple top schedules have been found. Only one schedule can be the top schedule.");
-
-    next_sched = next_sched->next;
-  }
+	    {
+	    ptr = ptr->next;
+      if (!ptr->usedAsSub)
+        {
+        found_top_sched = TRUE;
+        break;
+        }  
+	    }
+      Schedule *next_sched = ptr->next;
+      while (next_sched != NULL && found_top_sched == TRUE)
+      {
+        if (!next_sched->usedAsSub)
+          error(400, "Multiple top schedules have been found. Only one schedule can be the top schedule.");
+      next_sched = next_sched->next;
+      }
+      
+      if (found_top_sched == FALSE)
+	error(400,"Unable to find top level schedule.\nA top level schedule must not used as a sub-schedule.");
 
       cout << "top_schedule '" << ptr->schedName << "':" << endl;
     }


### PR DESCRIPTION
The changes introduced in #245 inadvertently changed the way ALARA identifies the top schedule. Before that PR, the `while` loop would terminate when a single top schedule was identified, but no error was produced when multiple top schedules were part of the input. After #245 was merged, however, the loop would no longer terminate upon finding the schedule, so the very last schedule in the list is now incorrectly considered as top. This PR attempts to fix the issue using two separate `while` loops: one to break the loop after finding the top schedule, and another to produce the error message. 