### PR TITLE
Moving pypact import to live within FISPACT-II class 

### DIFF
--- a/tools/alara_output_processing/alara_output_processing.py
+++ b/tools/alara_output_processing/alara_output_processing.py
@@ -1,6 +1,5 @@
 import pandas as pd
 import argparse
-import pypact
 from operator import gt, lt, ge
 from warnings import warn
 from csv import DictReader
@@ -364,6 +363,14 @@ class FispactParser:
             all_nucs (set): Set of all nuclides catalogued in the inventory
                 across all times.
         '''
+
+        # Import Pypact only within FispactParser
+        try:
+            import pypact
+        except ImportError:
+            raise ImportError(
+                'Pypact must be installed to parse FISPACT-II output files.'
+            )
 
         with pypact.Reader(output_path) as output:
             rows = []


### PR DESCRIPTION
This PR follows design choices I made in #257 for external software specific Python modules (i.e. `openmc`, `openmc.deplete`, `openmc.data`) to be imported within the relevant class for the special handling for OpenMC. Likewise, I figured it appropriate to now do the same for FISPACT-II data parsing, which relies on the Python module `pypact`, whose import is now done at the start of `FispactParser.fispact_to_adf()`.