### PR TITLE
Allowing for Zeroing of Decay Responses after Many Half-Lives

### DIFF
--- a/tools/alara_output_processing/alara_output_plotting.py
+++ b/tools/alara_output_processing/alara_output_plotting.py
@@ -16,6 +16,8 @@ def preprocess_data(
     sort_by_time='',
     pre_irrad=False,
     head=None,
+    decay_zeroing=True,
+    half_lives=10
 ):
     '''
     Prepare an ALARADFrame containing data from multiple runs and potentially
@@ -50,9 +52,17 @@ def preprocess_data(
         head (int or None, optional): Option by which to truncate the
             ALARADFrame to a particular number of rows.
             (Defaults to None)
+        decay_zeroing (bool, optional): Option to overwrite individual nuclide
+            responses after the number of half-lives set in the half_lives
+            parameter to zero to eliminate round-off error for long cooling
+            times (relative to half-life length).
+            (Defaults to True)
+        half_lives (int or float, optional): Option to specify the number of
+            half-lives to pass in cooling time before zeroing subsequent decay
+            responses. Only relevant if decay_zeroing is True.
+            (Defaults to 10)
         
     Returns:
-        times (list of floats): Chronological list of converted cooling times.
         filtered (alara_output_processing.ALARADFrame): Modified copy of input
             adf containing only rows that match all conditions in run_lbl,
             variable, and (if present) nuclides.
@@ -71,6 +81,9 @@ def preprocess_data(
         filter_dict['nuclide'] = nuclides
     
     filtered = adf.filter_rows(filter_dict)
+
+    if decay_zeroing:
+        filtered = filtered.zero_long_decay_responses(half_lives=half_lives)
 
     preset_time_unit = filtered['time_unit'].unique()[0]
     if time_unit != preset_time_unit:
@@ -257,7 +270,14 @@ def plot_or_scatter(plot_type, ax, x, y, label, color, style):
         )
 
 def pie_chart_aggregation(
-        adf, run_lbl, variable, threshold, time_unit, pre_irrad=False
+        adf,
+        run_lbl,
+        variable,
+        threshold,
+        time_unit,
+        pre_irrad=False,
+        decay_zeroing=True,
+        half_lives=10
 ):
     '''
     Prepare an aggregated ALARADFrame for single or multiple pie chart
@@ -276,6 +296,15 @@ def pie_chart_aggregation(
             (Defaults to 's')
         pre_irrad (bool, optional): Option to include pre-irradiation values.
             (Defaults to False)
+        decay_zeroing (bool, optional): Option to overwrite individual nuclide
+            responses after the number of half-lives set in the half_lives
+            parameter to zero to eliminate round-off error for long cooling
+            times (relative to half-life length).
+            (Defaults to True)
+        half_lives (int or float, optional): Option to specify the number of
+            half-lives to pass in cooling time before zeroing subsequent decay
+            responses. Only relevant if decay_zeroing is True.
+            (Defaults to 10)
 
     Returns:
         agg (alara_output_processing.ALARADFrame): Processed ALARADFrame
@@ -288,7 +317,9 @@ def pie_chart_aggregation(
         run_lbl=run_lbl,
         variable=variable,
         time_unit=time_unit,
-        pre_irrad=pre_irrad
+        pre_irrad=pre_irrad,
+        decay_truncation=decay_zeroing,
+        half_lives=half_lives
     )
     rel = filtered.calculate_relative_vals()
     agg = aop.aggregate_small_percentages(rel, threshold)
@@ -466,6 +497,8 @@ def plot_single_response(
     time_unit='s',
     sort_by_time='shutdown',
     head=None,
+    decay_zeroing=True,
+    half_lives=10,
     total=False,
     yscale='log',
     ymin=None,
@@ -508,7 +541,16 @@ def plot_single_response(
             (Defaults to 'shutdown')
         head (int or None, optional): Option by which to truncate the
             ALARADFrame to a particular number of rows.
-            (Defaults to None)           
+            (Defaults to None)
+        decay_zeroing (bool, optional): Option to overwrite individual nuclide
+            responses after the number of half-lives set in the half_lives
+            parameter to zero to eliminate round-off error for long cooling
+            times (relative to half-life length).
+            (Defaults to True)
+        half_lives (int or float, optional): Option to specify the number of
+            half-lives to pass in cooling time before zeroing subsequent decay
+            responses. Only relevant if decay_zeroing is True.
+            (Defaults to 10)
         total (bool, optional): Option to include the cumulative total
             contribution from all isotopes towards the select variable in the
             plot. If total=True, the total array will be treated equivalently
@@ -556,6 +598,8 @@ def plot_single_response(
             time_unit=time_unit,
             sort_by_time=sort_by_time,
             head=head,
+            decay_truncation=decay_zeroing,
+            half_lives=half_lives
         )
         data_list.append((run_lbl, filtered, piv, style))
 

--- a/tools/alara_output_processing/alara_output_plotting.py
+++ b/tools/alara_output_processing/alara_output_plotting.py
@@ -16,7 +16,6 @@ def preprocess_data(
     sort_by_time='',
     pre_irrad=False,
     head=None,
-    decay_zeroing=True,
     half_lives=10
 ):
     '''
@@ -57,9 +56,11 @@ def preprocess_data(
             parameter to zero to eliminate round-off error for long cooling
             times (relative to half-life length).
             (Defaults to True)
-        half_lives (int or float, optional): Option to specify the number of
-            half-lives to pass in cooling time before zeroing subsequent decay
-            responses. Only relevant if decay_zeroing is True.
+        half_lives (int, float, or None, optional): Option to specify the
+            number of half-lives to pass in cooling time before zeroing
+            subsequent decay responses. Used to eliminate round-off error for
+            long cooling times (relative to half-life length). To avoid half-
+            life zeroing, set half_lives to None.
             (Defaults to 10)
         
     Returns:
@@ -82,7 +83,7 @@ def preprocess_data(
     
     filtered = adf.filter_rows(filter_dict)
 
-    if decay_zeroing:
+    if half_lives is not None:
         filtered = filtered.zero_long_decay_responses(half_lives=half_lives)
 
     preset_time_unit = filtered['time_unit'].unique()[0]
@@ -276,7 +277,6 @@ def pie_chart_aggregation(
         threshold,
         time_unit,
         pre_irrad=False,
-        decay_zeroing=True,
         half_lives=10
 ):
     '''
@@ -296,14 +296,11 @@ def pie_chart_aggregation(
             (Defaults to 's')
         pre_irrad (bool, optional): Option to include pre-irradiation values.
             (Defaults to False)
-        decay_zeroing (bool, optional): Option to overwrite individual nuclide
-            responses after the number of half-lives set in the half_lives
-            parameter to zero to eliminate round-off error for long cooling
-            times (relative to half-life length).
-            (Defaults to True)
-        half_lives (int or float, optional): Option to specify the number of
-            half-lives to pass in cooling time before zeroing subsequent decay
-            responses. Only relevant if decay_zeroing is True.
+        half_lives (int, float, or None, optional): Option to specify the
+            number of half-lives to pass in cooling time before zeroing
+            subsequent decay responses. Used to eliminate round-off error for
+            long cooling times (relative to half-life length). To avoid half-
+            life zeroing, set half_lives to None.
             (Defaults to 10)
 
     Returns:
@@ -318,7 +315,6 @@ def pie_chart_aggregation(
         variable=variable,
         time_unit=time_unit,
         pre_irrad=pre_irrad,
-        decay_zeroing=decay_zeroing,
         half_lives=half_lives
     )
     rel = filtered.calculate_relative_vals()
@@ -497,7 +493,6 @@ def plot_single_response(
     time_unit='s',
     sort_by_time='shutdown',
     head=None,
-    decay_zeroing=True,
     half_lives=10,
     total=False,
     yscale='log',
@@ -542,14 +537,11 @@ def plot_single_response(
         head (int or None, optional): Option by which to truncate the
             ALARADFrame to a particular number of rows.
             (Defaults to None)
-        decay_zeroing (bool, optional): Option to overwrite individual nuclide
-            responses after the number of half-lives set in the half_lives
-            parameter to zero to eliminate round-off error for long cooling
-            times (relative to half-life length).
-            (Defaults to True)
-        half_lives (int or float, optional): Option to specify the number of
-            half-lives to pass in cooling time before zeroing subsequent decay
-            responses. Only relevant if decay_zeroing is True.
+        half_lives (int, float, or None, optional): Option to specify the
+            number of half-lives to pass in cooling time before zeroing
+            subsequent decay responses. Used to eliminate round-off error for
+            long cooling times (relative to half-life length). To avoid half-
+            life zeroing, set half_lives to None.
             (Defaults to 10)
         total (bool, optional): Option to include the cumulative total
             contribution from all isotopes towards the select variable in the
@@ -598,7 +590,6 @@ def plot_single_response(
             time_unit=time_unit,
             sort_by_time=sort_by_time,
             head=head,
-            decay_zeroing=decay_zeroing,
             half_lives=half_lives
         )
         data_list.append((run_lbl, filtered, piv, style))

--- a/tools/alara_output_processing/alara_output_plotting.py
+++ b/tools/alara_output_processing/alara_output_plotting.py
@@ -318,7 +318,7 @@ def pie_chart_aggregation(
         variable=variable,
         time_unit=time_unit,
         pre_irrad=pre_irrad,
-        decay_truncation=decay_zeroing,
+        decay_zeroing=decay_zeroing,
         half_lives=half_lives
     )
     rel = filtered.calculate_relative_vals()
@@ -598,7 +598,7 @@ def plot_single_response(
             time_unit=time_unit,
             sort_by_time=sort_by_time,
             head=head,
-            decay_truncation=decay_zeroing,
+            decay_zeroing=decay_zeroing,
             half_lives=half_lives
         )
         data_list.append((run_lbl, filtered, piv, style))

--- a/tools/alara_output_processing/alara_output_processing.py
+++ b/tools/alara_output_processing/alara_output_processing.py
@@ -859,6 +859,60 @@ class ALARADFrame(pd.DataFrame):
 
         return pd.concat([self, totals], ignore_index=True)
 
+    def zero_long_decay_responses(self, half_lives=10):
+        '''
+        For each radionuclide in an ALARADFrame, overwrite all response values
+            at cooling times greater than a given number of half-lives to 0.
+            This zeroing corrects for round-off errors that arise from decay
+            responses approaching lower limits of machine precision following
+            the exponential curve of radioactive decay. A recommended number
+            of half-lives after which to overwrite is 10, at which point the
+            inventory of any given radionuclide will be <0.1% of its maximum.
+
+        Arguments:
+            self (alara_output_processing.ALARADFrame): Specialized DataFrame
+                for ALARA output data.
+            half_lives (int or float, optional): Option to specify the number of
+                half-lives to pass in cooling time before zeroing subsequent decay
+                responses.
+                (Defaults to 10)
+
+        Returns:
+            adf (alara_output_processing.ALARADFrame): Modified ALARADFrame in
+                which individual nuclide responses after a given number of half-
+                lives are set to zero.
+        '''
+
+        # To achieve <1% of maximum inventory for each nuclide, the minimum
+        # number of recommended half-lives to be elapsed before truncation is set
+        # at 7, however, using the default value of 10 is preferable to minimize
+        # excessive deletion.
+        minimum_half_lives = 7
+        if half_lives < minimum_half_lives:
+            warn((
+                f'Decay truncation after only {half_lives} half-lives is ' \
+                'likely insufficient to appropriately approximate null ' \
+                'decay responses at these times. \n Consider increasing ' \
+                'half_lives parameter.'
+            ))
+
+        zeroed_adf = self.copy()
+
+        for nuc in set(zeroed_adf['nuclide'].unique()) - {'total'}:
+            thalf = zeroed_adf.filter_rows({
+                'nuclide' : nuc
+            })['half_life'].unique()[0]
+            if thalf > 0:
+                zeroed_adf.loc[
+                    (
+                        (zeroed_adf['nuclide'] == nuc)
+                        & (zeroed_adf['time'] > thalf * half_lives)
+                    ),
+                    'value'
+                ] = 0
+
+        return zeroed_adf
+
     #### FISPACT-II Hybrid ALARADFrame Operations ####
     ####    (ALARADFrames with FISPACT-II data)   ####
 


### PR DESCRIPTION
This PR includes changes to both `alara_output_processing` modules to handle decay responses for individual radionuclides at long cooling times (relative to the length their half-lives). After many half-lives have elapsed (~10) the actual values of any given decay response for a radionuclide will be effectively zero, but will continue to decay exponentially ad infinitum. Due to limitations of machine precision, though, at a certain threshold, it may be more appropriate to simply consider these values to be 0, rather than their calculated values. To resolve this, I have added a new method to the `ALARADFrame` class in `alara_output_processing/alara_output_processing.py` to set the response values for each radionuclide present in an ALARADFrame to zero after a set number of half-lives has elapsed. Additionally, I have implemented this within `alara_output_plotting.preprocess_data()` to effectuate this correction by default, with the option for user override should they wish to retain the data as-is.

I will apply the changes that I have made here to my FISPACT-II/ALARA comparisons to see if this appropriately resolves #260, in the sense of the functional issue being round-off error, as opposed to discrepancies in decay libraries, which are expected to be minimal.