### PR TITLE
Resolving ALARAJOYWrapper over-filtering of certain excitation reactions

### DIFF
--- a/tools/ALARAJOYWrapper/preprocess_fendl3.py
+++ b/tools/ALARAJOYWrapper/preprocess_fendl3.py
@@ -281,6 +281,7 @@ def subtract_gas_from_totals(all_rxns):
     gas_tuples = list(rxd.GAS_DF[['kza', 'total_mt']].itertuples(index=False))
     for parent in all_rxns:
         for gKZA, gMT in gas_tuples:
+            gMT = str(gMT)
             if gKZA in all_rxns[parent] and gMT in all_rxns[parent][gKZA]:
                 for gRxn in all_rxns[parent][gKZA]:
                     if gRxn != gMT:

--- a/tools/ALARAJOYWrapper/tendl_processing.py
+++ b/tools/ALARAJOYWrapper/tendl_processing.py
@@ -192,7 +192,7 @@ def determine_all_excitations(endf_path, MTs, pKZA, mt_dict):
 
         # Account for cases of explicit MF3 excitation reactions without
         # corresponding cumulative MTs (i.e. (n,a0) [MT=800] for C-13)
-        elif cumulative_MT not in MTs:
+        elif cumulative_MT is not None and cumulative_MT not in MTs:
             M = np.where(EXCITATION_DICT[cumulative_MT] == MT)[0][0]
             # MT = 50 is forbidden in ENDF6, so scattering reactions require
             # an index adjustment compared to other state-explcit reactions
@@ -391,61 +391,63 @@ def iterate_MTs(
             reaction pathways for the given parent and its MTs.
     """
 
+    filtered_MTs = MTs - EXCITATION_REACTIONS
     for MT in MTs:
-        if (
-            MT not in EXCITATION_REACTIONS
-            or REVERSE_EXCITATION_DICT[MT] not in MTs
-        ):
-            xs_lines = xs_line_dict[MT]
-            M_values = list(isomer_dict[MT].values())[0]
-            isomer_specific_rxns = process_xsections(xs_lines, M_values)
-            rxn = mt_dict[MT]
-            gas = rxn['gas']
-            
-            # Calculate dKZA values for each excitation pathway in MF10
-            for M, sigmas in isomer_specific_rxns.items():
-                emitted = rxn['emitted']
-                dKZA = (((pKZA // 10) * 10 + rxn['delKZA']) // 10) * 10 + M
-                if gas:
-                    dKZA = GAS_DF.loc[GAS_DF['gas'] == gas, 'kza'].iat[0]
+        cumulative_MT = REVERSE_EXCITATION_DICT.get(MT)
+        if cumulative_MT is not None and cumulative_MT not in MTs:
+            filtered_MTs.add(MT)
 
-                # Remove ENDF isomer tags for explicit excitation reactions
-                if emitted[-1].isdigit() or emitted[-1] == 'c':
-                    emitted = emitted[:-1]
+    for MT in filtered_MTs:
+        xs_lines = xs_line_dict[MT]
+        M_values = list(isomer_dict[MT].values())[0]
+        isomer_specific_rxns = process_xsections(xs_lines, M_values)
+        rxn = mt_dict[MT]
+        gas = rxn['gas']
+        
+        # Calculate dKZA values for each excitation pathway in MF10
+        for M, sigmas in isomer_specific_rxns.items():
+            emitted = rxn['emitted']
+            dKZA = (((pKZA // 10) * 10 + rxn['delKZA']) // 10) * 10 + M
+            if gas:
+                dKZA = GAS_DF.loc[GAS_DF['gas'] == gas, 'kza'].iat[0]
 
-                # Signify isomeric state in ALARA formatting with a "*" for
-                # each excited level  
-                if M > 0:
-                    emitted += '*'
+            # Remove ENDF isomer tags for explicit excitation reactions
+            if emitted[-1].isdigit() or emitted[-1] == 'c':
+                emitted = emitted[:-1]
 
-                if dKZA in eaf_nucs or M == 0:
-                    all_rxns[pKZA][dKZA][str(MT) + '*' * M] = {
-                        'emitted'    :  emitted,
-                        'xsections'  :  sigmas
+            # Signify isomeric state in ALARA formatting with a "*" for
+            # each excited level  
+            if M > 0:
+                emitted += '*'
+
+            if dKZA in eaf_nucs or M == 0:
+                all_rxns[pKZA][dKZA][str(MT) + '*' * M] = {
+                    'emitted'    :  emitted,
+                    'xsections'  :  sigmas
+                }
+
+            else:
+                dKZA = ((dKZA - M) // 10) * 10
+                special_MT = -1
+                
+                if M > 1:
+                    dKZA = incrementally_deexcite_isomer(
+                        M, dKZA, eaf_nucs
+                    )
+
+                if dKZA not in all_rxns[pKZA]:
+                    all_rxns[pKZA][dKZA] = defaultdict(dict)
+
+                if special_MT not in all_rxns[pKZA][dKZA]:
+                    all_rxns[pKZA][dKZA][special_MT] = {
+                        'emitted'  : emitted,
+                        'xsections': np.zeros(VITAMIN_J_ENERGY_GROUPS)
                     }
 
-                else:
-                    dKZA = ((dKZA - M) // 10) * 10
-                    special_MT = -1
-                    
-                    if M > 1:
-                        dKZA = incrementally_deexcite_isomer(
-                            M, dKZA, eaf_nucs
-                        )
-
-                    if dKZA not in all_rxns[pKZA]:
-                        all_rxns[pKZA][dKZA] = defaultdict(dict)
-
-                    if special_MT not in all_rxns[pKZA][dKZA]:
-                        all_rxns[pKZA][dKZA][special_MT] = {
-                            'emitted'  : emitted,
-                            'xsections': np.zeros(VITAMIN_J_ENERGY_GROUPS)
-                        }
-
-                    all_rxns[pKZA][dKZA][special_MT][
-                        'xsections'
-                    ] += np.pad(
-                        sigmas, (0, VITAMIN_J_ENERGY_GROUPS - len(sigmas))
-                    )
+                all_rxns[pKZA][dKZA][special_MT][
+                    'xsections'
+                ] += np.pad(
+                    sigmas, (0, VITAMIN_J_ENERGY_GROUPS - len(sigmas))
+                )
 
     return all_rxns

--- a/tools/ALARAJOYWrapper/tendl_processing.py
+++ b/tools/ALARAJOYWrapper/tendl_processing.py
@@ -193,8 +193,7 @@ def determine_all_excitations(endf_path, MTs, pKZA, mt_dict):
         # Account for cases of explicit MF3 excitation reactions without
         # corresponding cumulative MTs (i.e. (n,a0) [MT=800] for C-13)
         elif cumulative_MT not in MTs:
-            cumulative_arange = EXCITATION_DICT[cumulative_MT]
-            M = np.where(cumulative_arange == MT)[0][0]
+            M = np.where(EXCITATION_DICT[cumulative_MT] == MT)[0][0]
             if cumulative_MT == 4:
                 M += 1
             isomer_dict[MT][3].append(M)

--- a/tools/ALARAJOYWrapper/tendl_processing.py
+++ b/tools/ALARAJOYWrapper/tendl_processing.py
@@ -7,15 +7,21 @@ import warnings
 import numpy as np
 
 VITAMIN_J_ENERGY_GROUPS = 175
-EXCITATION_REACTIONS = set(np.concatenate((
-    np.arange(51 ,  92), # (n,n*)  reactions
-    np.arange(601, 650), # (n,p*)  reactions
-    np.arange(651, 700), # (n,d*)  reactions
-    np.arange(700, 750), # (n,t*)  reactions
-    np.arange(750, 800), # (n,h*)  reactions
-    np.arange(800, 850), # (n,a*)  reactions
-    np.arange(875, 892), # (n,2n*) reactions
-)))
+EXCITATION_DICT = {
+    4   : np.arange(51 ,  92), # (n,n*)  reactions
+    103 : np.arange(601, 650), # (n,p*)  reactions
+    104 : np.arange(651, 700), # (n,d*)  reactions
+    105 : np.arange(700, 750), # (n,t*)  reactions
+    106 : np.arange(750, 800), # (n,h*)  reactions
+    107 : np.arange(800, 850), # (n,a*)  reactions
+    16  : np.arange(875, 892), # (n,2n*) reactions
+}
+EXCITATION_REACTIONS = set(np.concatenate(list(EXCITATION_DICT.values())))
+REVERSE_EXCITATION_DICT = {
+    val: key
+    for key, arr in EXCITATION_DICT.items()
+    for val in arr
+}
 
 def get_isotope(stem):
     """
@@ -162,6 +168,7 @@ def determine_all_excitations(endf_path, MTs, pKZA, mt_dict):
     isomer_dict = defaultdict(lambda: defaultdict(list))
 
     for MT in MTs:
+        cumulative_MT = REVERSE_EXCITATION_DICT.get(MT)
         if MT not in EXCITATION_REACTIONS:
             za = f'{(pKZA // 10) * 10 + mt_dict[MT]['delKZA']}'[:-1]
 
@@ -183,6 +190,15 @@ def determine_all_excitations(endf_path, MTs, pKZA, mt_dict):
             if not isomer_dict[MT]:
                 isomer_dict[MT][3].append(0)
 
+        # Account for cases of explicit MF3 excitation reactions without
+        # corresponding cumulative MTs (i.e. (n,a0) [MT=800] for C-13)
+        elif cumulative_MT not in MTs:
+            cumulative_arange = EXCITATION_DICT[cumulative_MT]
+            M = np.where(cumulative_arange == MT)[0][0]
+            if cumulative_MT == 4:
+                M += 1
+            isomer_dict[MT][3].append(M)
+  
     return isomer_dict
 
 def _gendf_parse_control(line):
@@ -374,51 +390,59 @@ def iterate_MTs(
             reaction pathways for the given parent and its MTs.
     """
 
-    # Avoid duplicate isomer cross-sections -- excitations already
-    # covered by MF 9/10 cumulative reactions
-    for MT in (MTs - EXCITATION_REACTIONS):
-        xs_lines = xs_line_dict[MT]
-        M_values = list(isomer_dict[MT].values())[0]
-        isomer_specific_rxns = process_xsections(xs_lines, M_values)
-        rxn = mt_dict[MT]
-        gas = rxn['gas']
-        
-        # Calculate dKZA values for each excitation pathway in MF10
-        for M, sigmas in isomer_specific_rxns.items():
-            emitted = rxn['emitted']
-            dKZA = (((pKZA // 10) * 10 + rxn['delKZA']) // 10) * 10 + M
-            if gas:
-                dKZA = GAS_DF.loc[GAS_DF['gas'] == gas, 'kza'].iat[0]
+    for MT in MTs:
+        if (
+            MT not in EXCITATION_REACTIONS
+            or REVERSE_EXCITATION_DICT[MT] not in MTs
+        ):
+            xs_lines = xs_line_dict[MT]
+            M_values = list(isomer_dict[MT].values())[0]
+            isomer_specific_rxns = process_xsections(xs_lines, M_values)
+            rxn = mt_dict[MT]
+            gas = rxn['gas']
+            
+            # Calculate dKZA values for each excitation pathway in MF10
+            for M, sigmas in isomer_specific_rxns.items():
+                emitted = rxn['emitted']
+                dKZA = (((pKZA // 10) * 10 + rxn['delKZA']) // 10) * 10 + M
+                if gas:
+                    dKZA = GAS_DF.loc[GAS_DF['gas'] == gas, 'kza'].iat[0]
 
-            if M > 0:
-                emitted += '*'
+                # Remove ENDF isomer tags for explicit excitation reactions
+                if emitted[-1].isdigit() or emitted[-1] == 'c':
+                    emitted = emitted[:-1]
 
-            if dKZA in eaf_nucs or M == 0:
-                all_rxns[pKZA][dKZA][str(MT) + '*' * M] = {
-                    'emitted'    :  emitted,
-                    'xsections'  :  sigmas
-                }
+                # Signify isomeric state in ALARA formatting with a "*" for
+                # each excited level  
+                if M > 0:
+                    emitted += '*'
 
-            else:
-                dKZA = ((dKZA - M) // 10) * 10
-                special_MT = -1
-                
-                if M > 1:
-                    dKZA = incrementally_deexcite_isomer(M, dKZA, eaf_nucs)
-
-                if dKZA not in all_rxns[pKZA]:
-                    all_rxns[pKZA][dKZA] = defaultdict(dict)
-
-                if special_MT not in all_rxns[pKZA][dKZA]:
-                    all_rxns[pKZA][dKZA][special_MT] = {
-                        'emitted'  : emitted,
-                        'xsections': np.zeros(VITAMIN_J_ENERGY_GROUPS)
+                if dKZA in eaf_nucs or M == 0:
+                    all_rxns[pKZA][dKZA][str(MT) + '*' * M] = {
+                        'emitted'    :  emitted,
+                        'xsections'  :  sigmas
                     }
 
-                all_rxns[pKZA][dKZA][special_MT][
-                    'xsections'
-                ] += np.pad(
-                    sigmas, (0, VITAMIN_J_ENERGY_GROUPS - len(sigmas))
-                )
+                else:
+                    dKZA = ((dKZA - M) // 10) * 10
+                    special_MT = -1
+                    
+                    if M > 1:
+                        dKZA = incrementally_deexcite_isomer(M, dKZA, eaf_nucs)
+
+                    if dKZA not in all_rxns[pKZA]:
+                        all_rxns[pKZA][dKZA] = defaultdict(dict)
+
+                    if special_MT not in all_rxns[pKZA][dKZA]:
+                        all_rxns[pKZA][dKZA][special_MT] = {
+                            'emitted'  : emitted,
+                            'xsections': np.zeros(VITAMIN_J_ENERGY_GROUPS)
+                        }
+
+                    all_rxns[pKZA][dKZA][special_MT][
+                        'xsections'
+                    ] += np.pad(
+                        sigmas, (0, VITAMIN_J_ENERGY_GROUPS - len(sigmas))
+                    )
 
     return all_rxns

--- a/tools/ALARAJOYWrapper/tendl_processing.py
+++ b/tools/ALARAJOYWrapper/tendl_processing.py
@@ -194,6 +194,8 @@ def determine_all_excitations(endf_path, MTs, pKZA, mt_dict):
         # corresponding cumulative MTs (i.e. (n,a0) [MT=800] for C-13)
         elif cumulative_MT not in MTs:
             M = np.where(EXCITATION_DICT[cumulative_MT] == MT)[0][0]
+            # MT = 50 is forbidden in ENDF6, so scattering reactions require
+            # an index adjustment compared to other state-explcit reactions
             if cumulative_MT == 4:
                 M += 1
             isomer_dict[MT][3].append(M)

--- a/tools/ALARAJOYWrapper/tendl_processing.py
+++ b/tools/ALARAJOYWrapper/tendl_processing.py
@@ -429,7 +429,9 @@ def iterate_MTs(
                     special_MT = -1
                     
                     if M > 1:
-                        dKZA = incrementally_deexcite_isomer(M, dKZA, eaf_nucs)
+                        dKZA = incrementally_deexcite_isomer(
+                            M, dKZA, eaf_nucs
+                        )
 
                     if dKZA not in all_rxns[pKZA]:
                         all_rxns[pKZA][dKZA] = defaultdict(dict)


### PR DESCRIPTION
Following the updates in #265, I was going back to recreate the FISPACT-II/ALARA comparisons, starting with the EU-DEMO "Activation Handbook" irradiations. When doing so, I noticed that our most recent update to the excitation handling from the final, merged version #229 resurrected a particular type of excitation issue that had been briefly resolved in an earlier iteration, though without my full understanding of why.

Recalling my first presentation of the "Activation Handbook" comparisons, I had noticed that there was a significant under-production of <sup>10</sup>Be from the irradiation of carbon. Given that the primary production pathway for <sup>10</sup>Be is <sup>13</sup>C _(n,α)_ <sup>10</sup>Be, I had assumed that this fell under the umbrella of gas handling issues, of which we had quite a few factors to resolve at that point.
<img width="832" height="590" alt="carbon_february" src="https://github.com/user-attachments/assets/b12e3ea2-4e2c-473d-8a67-38f069616350" />

Upon returning to this question, though, when I noticed that the <sup>10</sup>Be issue had resurfaced, I looked closer at the actual MTs contained in the <sup>13</sup>C TENDL-2017 file and saw that the relevant _(n,α)_ reaction was only logged under MT=800 (α emission with a daughter explicitly set to the ground state), without any inclusion of the cumulative MT = 107 (cumulative _(n,α)_ cross-sections). This was certainly surprising because, strictly sticking to the ENDF formatting would dictate that if there were to be any reactions in the MT 800-850 range, then MT = 107 should _necessarily_ exist. Why it does not is beyond me, but probably fits in with some of the general frustration that I have encountered since working on this project within the nuclear data community towards TENDL's inconsistency around isomer handling...

Having identified this quirk in TENDL (which plausibly exists outside of <sup>13</sup>C, but even if it is unique, is still significant, given carbon's prominence in fusion materials -- and the desire to actually process the data correctly), this PR updates the way in which ALARAJOYWrapper handles explicit excitation MTs (i.e. 800) that do _not_ have corresponding cumulative MTs (i.e. 107) to be included and have the daughter excitation levels logged as a direct function of the determinism from the MT itself.

As a quick sanity check on the legitimacy of these changes, below are plots of the <sup>10</sup>Be response for the irradiation of carbon compared to FISPACT-II, which now demonstrates very strong agreement:

<img width="831" height="590" alt="be10" src="https://github.com/user-attachments/assets/521f9154-11a7-44a8-a189-05fba61f25e0" />

<img width="887" height="590" alt="be10_ratios" src="https://github.com/user-attachments/assets/0b1be5ae-19ff-4555-bf75-a6d7fd735821" />

