### PR TITLE
Small alaraplot updates -- revisited after rebase

### DIFF
--- a/tools/alara_output_processing/alara_output_plotting.py
+++ b/tools/alara_output_processing/alara_output_plotting.py
@@ -2,6 +2,8 @@ import numpy as np
 import pandas as pd
 import matplotlib.pyplot as plt
 from matplotlib import lines
+import matplotlib.cm as cm
+import matplotlib.colors as mcolors
 from warnings import warn
 import alara_output_processing as aop
 
@@ -106,7 +108,7 @@ def preprocess_data(
 
     return filtered, piv
 
-def build_color_map(cmap_name, all_nucs=[], pivs=None):
+def build_color_map(cmap_name, all_nucs=[], pivs=None, mark_thalf=False):
     '''
     Given a list of pivot DataFrames (one per run) or a 1D array-like data
         structure of nuclide string names, build a stable color mape keyed by
@@ -133,9 +135,14 @@ def build_color_map(cmap_name, all_nucs=[], pivs=None):
     if len(all_nucs) == 0:
         raise ValueError('Must input either all_nucs or pivs.')
 
-    color_map = {
-        lbl: cmap(i % cmap.N) for i, lbl in enumerate(sorted(all_nucs))
-    }
+    if mark_thalf:
+        color_map = {
+            lbl: cmap(0.4 + 0.55 * i / max(len(all_nucs)-1,1)) for i, lbl in enumerate(sorted(all_nucs))
+        }
+    else:
+        color_map = {
+            lbl: cmap(i % cmap.N) for i, lbl in enumerate(sorted(all_nucs))
+        }
 
     if 'Other' in set(all_nucs):
         color_map['Other'] = (0.8, 0.8, 0.8, 1.0)
@@ -190,20 +197,24 @@ def reformat_isotope(isotope):
         element = element.capitalize()
         return f'$^{{{A}}}${element}'
 
-def construct_legend(ax, data_comp=False):
+def construct_legend(ax, data_comp=False, legend_ax=None):
     '''
     Create a custom pyplot legend that exists outside of the grid itself and
         can group like-isotopes together from compared data sets for clarity.
     
     Arguments:
-        ax (matplotlib.axes._axes.Axes): Matplotlib axis object of the plot
+        ax (matplotlib.axes._axes.Axes): Matplotlib Axes object of the plot
             being constructed.
         data_comp (bool, optional): Boolean setting for comparison between two
             data sets.
             (Defaults to False)
+        legend_ax (matplotlib.axes._axes.Axes or None, optional): Optional
+            argument to construct the legend on a separate Matplotlib Axes
+            object than the plot itself.
     
     Returns:
-        None
+        legend (matplotlib.legend.Legend): Matplotlib Legend object containing
+            the constructed legend.
     '''
 
     handles, labels = ax.get_legend_handles_labels()
@@ -229,16 +240,27 @@ def construct_legend(ax, data_comp=False):
         grouped_labels.append(f'{isotope} {datalib}')
         prev_isotope = isotope
 
-    ax.legend(
+    if legend_ax:
+        target_ax = legend_ax
+        loc = 'center'
+        bbox_to_anchor = None
+    else:
+        target_ax = ax
+        loc = 'center left'
+        bbox_to_anchor = (1.025, 0.5)
+
+    legend = target_ax.legend(
         grouped_handles,
         grouped_labels,
-        loc='center left',
-        bbox_to_anchor=(1.025, 0.5),
+        loc=loc,
+        bbox_to_anchor=bbox_to_anchor,
         borderaxespad=0.,
         fontsize='small',
         handlelength=1.5,
         handletextpad=0.5,
     )
+
+    return legend
 
 def plot_or_scatter(plot_type, ax, x, y, label, color, style):
     '''
@@ -356,7 +378,7 @@ def pie_grid_relative_tables(
         piv.mean(axis=1).sort_values(ascending=False).index
     ]
     totals_row = pd.Series(totals, index=piv.columns)
-    total_name = f'Total {var_unit}'
+    total_name = f'Total [{var_unit}]'
     piv = pd.concat(
         [totals_row.to_frame(name=total_name).T, piv],
         axis=0
@@ -498,8 +520,11 @@ def plot_single_response(
     yscale='log',
     ymin=None,
     relative=False,
-    cmap_name = 'Dark2',
-    plot_type = 'plot'
+    cmap_name='Dark2',
+    plot_type='plot',
+    separate_legend=False,
+    control_run=None,
+    mark_thalf=False
 ):
     '''
     Create a simple x-y plot of a given variable tracked in an ALARA output
@@ -561,12 +586,28 @@ def plot_single_response(
             the plots. Reference guide for Matplotlib Colormaps can be found
             at matplotlib.org/stable/gallery/color/colormap_reference.html
             (Defaults to "Dark2")
+        separate_legend (bool, optional): Option to return the legend as a
+            separate Matplotlib Figure object. Can be useful for plots with
+            many nuclide series.
+            (Defaults to False)
+        control_run (str or None, optional): Option to set a control run to
+            against which to calculate time-series ratios for all other runs.
+            If used, must case-sensitively match one of the labels in the list
+            run_lbl.
+            (Defaults to '')
+        mark_thalf (bool, optional): Option to mark a vertical line for the
+            half-lives of all nuclides present in the plot.
+            (Defaults to False)
 
     Returns:
         fig (matplotlib.figure.Figure): Closed Matplotlib Figure object
             containing the constructed plot.
+        legend_fig (matplotlib.figure.Figure or None): Conditionally separated
+            Matplotlib Figure object containing only the plot's legend. None
+            if separate_legend argument is False.
     '''
 
+    ratio_plotting = (control_run is not None)
     data_comp = False
     fig, ax = plt.subplots(figsize=(10,6))
 
@@ -592,34 +633,73 @@ def plot_single_response(
             head=head,
             half_lives=half_lives
         )
-        data_list.append((run_lbl, filtered, piv, style))
 
-    color_map = build_color_map(
-        cmap_name=cmap_name,
-        pivs=[data[2] for data in data_list]
+        if run_lbl == control_run:
+            control_piv = piv
+        else:
+            data_list.append((run_lbl, filtered, piv, style))
+
+    pivs = [data[2] for data in data_list]
+    color_map = build_color_map(cmap_name=cmap_name, pivs=pivs)
+    thalf_cmap = build_color_map(
+        cmap_name='Reds', pivs=pivs, mark_thalf=mark_thalf
     )
+
+    plotted_nucs = []
     for run_lbl, filtered, piv, style in data_list:
         for nuc in piv.index:
             if nuc == 'total' and not total:
                 continue
 
-            label_suffix = f' ({run_lbl})' if data_comp else ''
+            try:
+                # Conditional vectorized division to calculate time-series
+                # ratio against the control run. If zeros exist in the control
+                # run, a zero-division RuntimeWarning will be raised, but does
+                # not cause plotting issues as NaNs will just not be plotted.
+                # If a ratio series starts/stops abruptly, this zero-division
+                # is the cause and is not necessarily an error, as various
+                # nuclides may not be present across all cooling times.
+                y = (
+                    piv.loc[nuc].to_numpy() / control_piv.loc[nuc].to_numpy()
+                    if ratio_plotting else piv.loc[nuc].tolist()
+                )
+            except KeyError:
+                print(f'KeyError: Missing {nuc} from {run_lbl}')
+                continue
 
+            label_suffix = f' ({run_lbl})' if data_comp else ''
             plot_or_scatter(
                 ax=ax,
                 plot_type=plot_type,
                 x=piv.columns,
-                y=piv.loc[nuc].tolist(),
+                y=y,
                 label=(nuc + label_suffix),
                 color=color_map[nuc],
                 style=style
             )
 
-    title_suffix = f'{variable} vs Cooling Time '
+            if mark_thalf and nuc not in plotted_nucs:
+                thalf = filtered.loc[
+                    filtered['nuclide'] == nuc, 'half_life'
+                ].iat[0]
+                plt.axvline(x=thalf, color=thalf_cmap[nuc], alpha=0.85, label=(
+                    rf'{nuc} ($t_{{1/2}} = {thalf:.2e}{time_unit}$)'
+                ))
+                plotted_nucs.append(nuc)
+
+    ylabel = f'{variable} [{filtered['var_unit'].unique()[0]}]'
+    title_suffix = (
+        f'Ratio of {variable} against {control_run}' if ratio_plotting
+        else f'{variable}'
+    ) + ' vs Cooling Time'
+
+    if ratio_plotting:
+        ylabel = f'Ratio of {variable} against {control_run}'
 
     if relative:
         title_suffix += 'Relative to Total at Each Cooling Time '
         yscale = 'linear'
+        ylabel = f'Proportion of Total {variable}'
 
     if head:
         title_suffix += (
@@ -632,22 +712,25 @@ def plot_single_response(
     )
 
     ax.set_title(title_prefix + title_suffix)
-    ax.set_ylabel(
-        f'Proportion of Total {variable}' if relative
-        else f'{variable} [{filtered['var_unit'].unique()[0]}]'
-    )
+    ax.set_ylabel(ylabel)
     ax.set_xlabel(f'Time ({time_unit})')
     ax.set_xscale('log')
     ax.set_yscale(yscale)
     if ymin:
         ax.set_ylim(bottom=ymin)
 
-    construct_legend(ax, data_comp)
+    legend_ax = None
+    if separate_legend:
+        n_items = len(color_map)
+        _, legend_ax = plt.subplots(figsize=(4, max(4, 0.3 * n_items)))
+        legend_ax.axis('off')
+
+    legend_fig = construct_legend(ax, data_comp, legend_ax)
 
     ax.grid(True)
     plt.tight_layout(rect=[0, 0, 0.85, 1])
 
-    return fig
+    return fig, legend_fig
 
 def single_time_pie_chart(
     agg,

--- a/tools/alara_output_processing/alara_output_plotting.py
+++ b/tools/alara_output_processing/alara_output_plotting.py
@@ -3,7 +3,6 @@ import pandas as pd
 import matplotlib.pyplot as plt
 from matplotlib import lines
 import matplotlib.cm as cm
-import matplotlib.colors as mcolors
 from warnings import warn
 import alara_output_processing as aop
 

--- a/tools/alara_output_processing/alara_output_plotting.py
+++ b/tools/alara_output_processing/alara_output_plotting.py
@@ -122,6 +122,10 @@ def build_color_map(cmap_name, all_nucs=[], pivs=None, mark_thalf=False):
         pivs (list of pandas.DataFrames or None, optional): List of pivot
             tables indexed by nuclide with values for each cooling time.
             (Defaults to None)
+        mark_thalf (bool, optional): Option to create a corresponding shade
+            for each nuclide's half-life to be plotted vertically alongside
+            the time series.
+            (Defaults to False)
     '''
     
     cmap = plt.cm.get_cmap(cmap_name)
@@ -137,7 +141,8 @@ def build_color_map(cmap_name, all_nucs=[], pivs=None, mark_thalf=False):
 
     if mark_thalf:
         color_map = {
-            lbl: cmap(0.4 + 0.55 * i / max(len(all_nucs)-1,1)) for i, lbl in enumerate(sorted(all_nucs))
+            lbl: cmap(0.4 + 0.55 * i / max(len(all_nucs)-1,1))
+            for i, lbl in enumerate(sorted(all_nucs))
         }
     else:
         color_map = {
@@ -651,21 +656,21 @@ def plot_single_response(
             if nuc == 'total' and not total:
                 continue
 
-            try:
-                # Conditional vectorized division to calculate time-series
-                # ratio against the control run. If zeros exist in the control
-                # run, a zero-division RuntimeWarning will be raised, but does
-                # not cause plotting issues as NaNs will just not be plotted.
-                # If a ratio series starts/stops abruptly, this zero-division
-                # is the cause and is not necessarily an error, as various
-                # nuclides may not be present across all cooling times.
-                y = (
-                    piv.loc[nuc].to_numpy() / control_piv.loc[nuc].to_numpy()
-                    if ratio_plotting else piv.loc[nuc].tolist()
-                )
-            except KeyError:
-                print(f'KeyError: Missing {nuc} from {run_lbl}')
+            if nuc not in filtered['nuclide'].unique():
+                warn(f'Missing {nuc} from {run_lbl}')
                 continue
+
+            # Vectorized division to calculate time-series ratio against the
+            # control run. If zeros exist in the control run, a zero-division
+            # RuntimeWarning will be raised, but does not cause plotting
+            # issues as NaNs will just not be plotted. If a ratio series
+            # starts/stops abruptly, this zero-division is the cause and is
+            # not necessarily an error, as various nuclides may not be present
+            # across all cooling times.
+
+            y = piv.loc[nuc].to_numpy()
+            if ratio_plotting:
+                y /= control_piv.loc[nuc].to_numpy()
 
             label_suffix = f' ({run_lbl})' if data_comp else ''
             plot_or_scatter(

--- a/tools/alara_output_processing/alara_output_plotting.py
+++ b/tools/alara_output_processing/alara_output_plotting.py
@@ -683,9 +683,7 @@ def plot_single_response(
             )
 
             if mark_thalf and nuc not in plotted_nucs:
-                thalf = filtered.loc[
-                    filtered['nuclide'] == nuc, 'half_life'
-                ].iat[0]
+                thalf = filtered.get_thalf(nuc)
                 plt.axvline(x=thalf, color=thalf_cmap[nuc], alpha=0.85, label=(
                     rf'{nuc} ($t_{{1/2}} = {thalf:.2e}{time_unit}$)'
                 ))

--- a/tools/alara_output_processing/alara_output_plotting.py
+++ b/tools/alara_output_processing/alara_output_plotting.py
@@ -544,7 +544,8 @@ def plot_single_response(
     Arguments:
         adf (alara_output_processing.ALARADFrame): ALARADFrame containing 
             response data from one or more ALARA runs.
-        run_lbl (str): Distinguisher of the specified ALARA run.
+        run_lbls (str or list of str): Distinguisher of the specified run or
+            list of distinguishers for multiple runs.
         variable (str): Name of the response variable.
         nuclides (str, list, or None, optional): Optional parameter for
             nuclide selection. For a single nuclide, input should be a string

--- a/tools/alara_output_processing/alara_output_plotting.py
+++ b/tools/alara_output_processing/alara_output_plotting.py
@@ -699,7 +699,7 @@ def plot_single_response(
         ylabel = f'Ratio of {variable} against {control_run}'
 
     if relative:
-        title_suffix += 'Relative to Total at Each Cooling Time '
+        title_suffix += ' Relative to Total at Each Cooling Time '
         yscale = 'linear'
         ylabel = f'Proportion of Total {variable}'
 


### PR DESCRIPTION
This PR takes over for #248. Upon attempting to rebase to be able to respond to an old change request on there from last month, I ran into some trouble with the Git history. Given that the most recent requested change was just to remove a single comment line, I figured it was not worth going through and untangling that Git mess, instead opting just to copy over the latest version of `alara_output_plotting.py` from the old PR to here and removing said line.

Below is the original description for #248:

> This PR includes a couple more small changes to tools/alara_output_processing/alara_output_plotting.py to improve versatility:

>1. Allowing plotting of the ratios of runs against each other, by creating a new optional parameter control_run, wherein the user can select one of the runs contained in the ADF against which to divide to calculate a time-series of ratios.

>2. Allowing for the legend to be created as a separate matplotlib.legend.Legend object, which can be helpful for plotting with legends with many series.

>3. Allowing plotting of vertical lines at the half-life times for each nuclide plotted (can be useful because it seems that it is at the first half life where ALARA and FISPACT-II decay behaviors diverge).
