### PR TITLE
Fix syntax errors in sched_post_processor.py

### DIFF
--- a/tools/sched_post_processor.py
+++ b/tools/sched_post_processor.py
@@ -59,7 +59,7 @@ def make_sch_sub_dict(sch_line):
     return sch_sub_dict
 
 
-def make_pe_sub_dict(pe_line, unit_multipliers):
+def make_pe_sub_dict(pe_line):
     pe_sub_dict = {
         "type" : "pulse_entry",
         "pe_dur": float(pe_line[1]) * unit_multipliers[pe_line[2]],
@@ -77,33 +77,29 @@ def make_nested_dict(lines):
     in the section of the output with schedule details.
     A sub-dictionary is created for each additional indented level.
     """
-    sched_tree = {0: {"children" : [] } }
+    sched_tree = {0: {"children": []}}
     line_idx = 0
     # next section of output
     current_sched = sched_tree[0]
     ancestors = [current_sched]
+    keywords = ["top_schedule", "schedule", "pulse_entry:"]
 
-    while not lines[line_idx].startswith("pulse_history:"):
+    while any(lines[line_idx].strip().startswith(keyword) for keyword in keywords):
         new_child_level = lines[line_idx].count("\t")
         tokens = lines[line_idx].strip().split()
-
-
         while new_child_level < len(ancestors):
             current_sched = ancestors.pop()
-
-        if tokens[0] == "schedule":
+        if tokens[0] == keywords[1]:
 
             current_sched["children"].append(make_sch_sub_dict(tokens))
             ancestors.append(current_sched)
             current_sched = current_sched["children"][-1]
 
-
-        elif tokens[0] == "pulse_entry:":
+        elif tokens[0] == keywords[2]:
             current_sched["children"].append(make_pe_sub_dict(tokens))
 
         line_idx += 1
-
-    return sch_dict
+    return sched_tree
 
 
 def parse_arg():

--- a/tools/sched_post_processor.py
+++ b/tools/sched_post_processor.py
@@ -82,20 +82,23 @@ def make_nested_dict(lines):
     # next section of output
     current_sched = sched_tree[0]
     ancestors = [current_sched]
-    keywords = ["top_schedule", "schedule", "pulse_entry:"]
+    top_schedule = "top_schedule"
+    schedule = "schedule"
+    pulse_entry = "pulse_entry:"
+    keywords = [top_schedule, schedule, pulse_entry]
 
     while any(lines[line_idx].strip().startswith(keyword) for keyword in keywords):
         new_child_level = lines[line_idx].count("\t")
         tokens = lines[line_idx].strip().split()
         while new_child_level < len(ancestors):
             current_sched = ancestors.pop()
-        if tokens[0] == keywords[1]:
+        if tokens[0] == schedule:
 
             current_sched["children"].append(make_sch_sub_dict(tokens))
             ancestors.append(current_sched)
             current_sched = current_sched["children"][-1]
 
-        elif tokens[0] == keywords[2]:
+        elif tokens[0] == pulse_entry:
             current_sched["children"].append(make_pe_sub_dict(tokens))
 
         line_idx += 1


### PR DESCRIPTION
There were some syntax errors and redundant function arguments that seem to have slipped through the cracks when the sched_post_processor.py tool was added. The processor also did not correctly account for extra lines in the output that come from added verbosity, due to the `while not line.startswith("pulse_history")` condition being overly generic.