### PR TITLE
Including Mean and Standard Deviation for alaraplot ratio plotting

### DIFF
--- a/tools/alara_output_processing/alara_output_plotting.py
+++ b/tools/alara_output_processing/alara_output_plotting.py
@@ -704,7 +704,7 @@ def plot_single_response(
             y = piv.loc[nuc].to_numpy()
             if ratio_plotting:
                 y /= control_piv.loc[nuc].to_numpy()
-                if not np.isnan(y.mean()):
+                if not np.isnan(y.mean()) and nuc == 'total':
                     mean = format_statistic(y.mean(), sig_figs)
                     sem = format_statistic(y.std() * len(y) ** -0.5, sig_figs)
                     label_suffix += (

--- a/tools/alara_output_processing/alara_output_plotting.py
+++ b/tools/alara_output_processing/alara_output_plotting.py
@@ -530,7 +530,7 @@ def plot_single_response(
     plot_type='plot',
     separate_legend=False,
     control_run=None,
-    sig_figs=4,
+    sig_figs=3,
     mark_thalf=False
 ):
     '''

--- a/tools/alara_output_processing/alara_output_plotting.py
+++ b/tools/alara_output_processing/alara_output_plotting.py
@@ -174,6 +174,8 @@ def split_label(label):
         parts = label.split('(')
         isotope = parts[0].strip()
         run_lbl = f'({parts[1].strip(')')})'
+        if '$\\mu' in run_lbl:
+            run_lbl = run_lbl[:-1]
     else:
         isotope = label.strip()
         run_lbl = ''
@@ -200,6 +202,30 @@ def reformat_isotope(isotope):
         element, A = isotope.split('-')
         element = element.capitalize()
         return f'$^{{{A}}}${element}'
+
+def format_statistic(statistic, sig_figs):
+    '''
+    Format a statistic to be written out in a plot legend with a desired
+        number of significant figures. Value written out in fixed-point
+        notation (i.e. 1.234) for values between 0.001 and 1000 or scientific
+        notation (i.e. 5.678e+09) for values outside of those bounds.
+
+    Arguments:
+        statistic (float): Statistic from a series (i.e. mean, standard
+            deviation of the mean, etc.).
+        sig_figs (int): Number of desired significant figures for the
+            representation of the statistic.
+
+    Returns:
+        formated_statistic (str): Value with the desired number of significant
+            figures, either in fixed-point or scientific notation
+    '''
+
+    return (
+        f'{statistic:.{sig_figs}f}'
+        if statistic > 1e-3 and statistic < 1e3
+        else f'{statistic:.{sig_figs}e}'
+    )
 
 def construct_legend(ax, data_comp=False, legend_ax=None):
     '''
@@ -528,6 +554,7 @@ def plot_single_response(
     plot_type='plot',
     separate_legend=False,
     control_run=None,
+    sig_figs=3,
     mark_thalf=False
 ):
     '''
@@ -600,6 +627,10 @@ def plot_single_response(
             If used, must case-sensitively match one of the labels in the list
             run_lbl.
             (Defaults to '')
+        sig_figs (int): Option to set a number of significant figures for the
+            represenation of statistics calculated for time-series ratios (in
+            conjunction with control_run).
+            (Defaults to 3)
         mark_thalf (bool, optional): Option to mark a vertical line for the
             half-lives of all nuclides present in the plot.
             (Defaults to False)
@@ -660,6 +691,8 @@ def plot_single_response(
                 warn(f'Missing {nuc} from {run_lbl}')
                 continue
 
+            label_suffix = f' ({run_lbl})' if data_comp else ''
+
             # Vectorized division to calculate time-series ratio against the
             # control run. If zeros exist in the control run, a zero-division
             # RuntimeWarning will be raised, but does not cause plotting
@@ -671,8 +704,12 @@ def plot_single_response(
             y = piv.loc[nuc].to_numpy()
             if ratio_plotting:
                 y /= control_piv.loc[nuc].to_numpy()
+                mean = format_statistic(y.mean(), sig_figs)
+                sem = format_statistic(y.std() * (len(y) ** -0.5), sig_figs)
+                label_suffix += (
+                    f'\n$\\mu = {mean}, \\ \\sigma_{{\\mu}} = {sem}$\n――――――'
+                )
 
-            label_suffix = f' ({run_lbl})' if data_comp else ''
             plot_or_scatter(
                 ax=ax,
                 plot_type=plot_type,

--- a/tools/alara_output_processing/alara_output_plotting.py
+++ b/tools/alara_output_processing/alara_output_plotting.py
@@ -175,7 +175,7 @@ def split_label(label):
         isotope = parts[0].strip()
         run_lbl = f'({parts[1].strip(')')})'
         if '$\\mu' in run_lbl:
-            run_lbl = run_lbl[:-1]
+            run_lbl = run_lbl.strip(')')
     else:
         isotope = label.strip()
         run_lbl = ''
@@ -202,30 +202,6 @@ def reformat_isotope(isotope):
         element, A = isotope.split('-')
         element = element.capitalize()
         return f'$^{{{A}}}${element}'
-
-def format_statistic(statistic, sig_figs):
-    '''
-    Format a statistic to be written out in a plot legend with a desired
-        number of significant figures. Value written out in fixed-point
-        notation (i.e. 1.234) for values between 0.001 and 1000 or scientific
-        notation (i.e. 5.678e+09) for values outside of those bounds.
-
-    Arguments:
-        statistic (float): Statistic from a series (i.e. mean, standard
-            deviation of the mean, etc.).
-        sig_figs (int): Number of desired significant figures for the
-            representation of the statistic.
-
-    Returns:
-        formated_statistic (str): Value with the desired number of significant
-            figures, either in fixed-point or scientific notation
-    '''
-
-    return (
-        f'{statistic:.{sig_figs}f}'
-        if statistic > 1e-3 and statistic < 1e3
-        else f'{statistic:.{sig_figs}e}'
-    )
 
 def construct_legend(ax, data_comp=False, legend_ax=None):
     '''
@@ -554,7 +530,7 @@ def plot_single_response(
     plot_type='plot',
     separate_legend=False,
     control_run=None,
-    sig_figs=3,
+    sig_figs=4,
     mark_thalf=False
 ):
     '''
@@ -705,11 +681,9 @@ def plot_single_response(
             if ratio_plotting:
                 y /= control_piv.loc[nuc].to_numpy()
                 if not np.isnan(y.mean()) and nuc == 'total':
-                    mean = format_statistic(y.mean(), sig_figs)
-                    sem = format_statistic(y.std() * len(y) ** -0.5, sig_figs)
                     label_suffix += (
-                        f'\n$\\mu = {mean},' \
-                        f'\\ \\sigma_{{\\mu}} = {sem}$\n――――――'
+                        f'\n$\\mu = {y.mean():.{sig_figs}g},' \
+                        f'\\ \\sigma = {y.std():.{sig_figs}g}$\n――――――'
                     )
 
             plot_or_scatter(

--- a/tools/alara_output_processing/alara_output_plotting.py
+++ b/tools/alara_output_processing/alara_output_plotting.py
@@ -704,11 +704,13 @@ def plot_single_response(
             y = piv.loc[nuc].to_numpy()
             if ratio_plotting:
                 y /= control_piv.loc[nuc].to_numpy()
-                mean = format_statistic(y.mean(), sig_figs)
-                sem = format_statistic(y.std() * (len(y) ** -0.5), sig_figs)
-                label_suffix += (
-                    f'\n$\\mu = {mean}, \\ \\sigma_{{\\mu}} = {sem}$\n――――――'
-                )
+                if not np.isnan(y.mean()):
+                    mean = format_statistic(y.mean(), sig_figs)
+                    sem = format_statistic(y.std() * len(y) ** -0.5, sig_figs)
+                    label_suffix += (
+                        f'\n$\\mu = {mean},' \
+                        f'\\ \\sigma_{{\\mu}} = {sem}$\n――――――'
+                    )
 
             plot_or_scatter(
                 ax=ax,


### PR DESCRIPTION
Follows #267.


This PR introduces a small change to the function `alara_output_plotting.plot_single_response()` for the time-series ratio plotting functionality to include the mean and standard error of the mean in the legend for each series. This offers a quantitative view to the similarity of the sample series against the control run, which I think will both be valuable for me as I am writing the ALARAJOY updates paper, and generally valuable for users.