### PR TITLE
Revised p0 and d0 reaction handling -- branched from main

### DIFF
--- a/tools/ALARAJOYWrapper/tendl_processing.py
+++ b/tools/ALARAJOYWrapper/tendl_processing.py
@@ -9,8 +9,8 @@ import numpy as np
 VITAMIN_J_ENERGY_GROUPS = 175
 EXCITATION_DICT = {
     4   : np.arange(51 ,  92), # (n,n*)  reactions
-    103 : np.arange(601, 650), # (n,p*)  reactions
-    104 : np.arange(651, 700), # (n,d*)  reactions
+    103 : np.arange(600, 650), # (n,p*)  reactions
+    104 : np.arange(650, 700), # (n,d*)  reactions
     105 : np.arange(700, 750), # (n,t*)  reactions
     106 : np.arange(750, 800), # (n,h*)  reactions
     107 : np.arange(800, 850), # (n,a*)  reactions


### PR DESCRIPTION
Follows #274, but branched from `main`, rather than from #271. Original description below:

>Previously, in #229, I must have accidentally not included MT 600 and 650 in the `EXCITATION_DICT` used for filtering duplicate excitation reaction pathways if the cumulative reactions are present as well. I noticed this problem because I was seeing an unreasonably high amount of <sup>14</sup>C production from the simulated irradiation of nitrogen, caused by the <sup>14</sup>N _(n,p)_ <sup>14</sup>C reaction. Upon looking to my DSV file, I saw duplicates of both the `70140 60140 p` and `70140 60130 d` reactions, explaining the overproduction. As it stood, `EXCITATION_DICT` did not include the explicit (n,p0) and (n,d0) as it should have, allowing them to sneak past the filtration system in `iterate_MTs()`. After this patch, the nitrogen reactions all look ok and I'm sure there are reactions for other elements that are affected by this.