### PR TITLE
alaraplot shading for dominant nuclide contributions to single response plots

### DIFF
--- a/tools/alara_output_processing/alara_output_plotting.py
+++ b/tools/alara_output_processing/alara_output_plotting.py
@@ -657,7 +657,8 @@ def plot_single_response(
     control_run=None,
     sig_figs=3,
     mark_thalf=False,
-    shading=False
+    shading=False,
+    shading_color_map={}
 ):
     '''
     Create a simple x-y plot of a given variable tracked in an ALARA output
@@ -740,6 +741,10 @@ def plot_single_response(
             particular nuclide is the dominant contributor to the plotted
             decay response.
             (Defaults to False)
+        shading_color_map (dict, optional): Option to import a pre-existing
+            nuclide color map to shade dominant regions consistently with
+            other plots.
+            (Defaults to {})
 
     Returns:
         fig (matplotlib.figure.Figure): Closed Matplotlib Figure object
@@ -747,6 +752,8 @@ def plot_single_response(
         legend_fig (matplotlib.figure.Figure or None): Conditionally separated
             Matplotlib Figure object containing only the plot's legend. None
             if separate_legend argument is False.
+        shading_color_map (dict): Color map for dominant nuclide shaded
+            regions. Only populated if shading=True.
     '''
 
     ratio_plotting = (control_run is not None)
@@ -802,8 +809,8 @@ def plot_single_response(
         cmap_name='Reds', pivs=pivs, mark_thalf=mark_thalf
     )
 
-    shading_color_map = {}
-    if shading:
+
+    if shading and not shading_color_map:
         shading_color_map = build_color_map(
             cmap_name=cmap_name, pivs=list(shade_pivs.values())
         )
@@ -931,7 +938,7 @@ def plot_single_response(
     ax.grid(True)
     plt.tight_layout(rect=[0, 0, 0.85, 1])
 
-    return fig, legend_fig
+    return fig, legend_fig, shading_color_map
 
 def single_time_pie_chart(
     agg,

--- a/tools/alara_output_processing/alara_output_plotting.py
+++ b/tools/alara_output_processing/alara_output_plotting.py
@@ -568,19 +568,23 @@ def shade_dominant_nuclides(piv, ax, color_map, cmap_name):
     # Calculate logarithmic half-way values for each cooling time for shading
     # to flow smoothly between nuclide regions
     logt = np.log10(times)
-    bounds = np.empty(len(times) + 1)
-    bounds[1:-1] = 10 ** ((logt[:-1] + logt[1:]) / 2)
-    bounds[0]    = 10 ** (logt[0] - (logt[1] - logt[0]) / 2)
-    bounds[-1]   = 10 ** (logt[-1] + (logt[-1] - logt[-2]) / 2)
+    half_delta_logt = 0.5 * np.diff(logt)
+    log_bounds = np.empty(len(times) + 1)
+    log_bounds[0] = logt[0] - half_delta_logt[0]
+    log_bounds[1:-1] = logt[:-1] + half_delta_logt
+    log_bounds[-1] = logt[-1] + half_delta_logt[-1]
+    bounds = np.nan_to_num(10**log_bounds, nan=0.0)
 
     # Calculate the time bounds for each dominant nuclide's period of leading
     # contribution to the response variable
     dominance_ranges = {}
     for i, nuc in enumerate(dominant_nucs):
         if nuc not in dominance_ranges:
-            dominance_ranges[nuc] = [bounds[i], bounds[i + 1]]
+            dominance_ranges[nuc] = [[bounds[i], bounds[i + 1]]]
+        elif dominance_ranges[nuc][-1][1] == bounds[i]:
+            dominance_ranges[nuc][-1][1] = bounds[i + 1]
         else:
-            dominance_ranges[nuc][1] = bounds[i + 1]
+            dominance_ranges[nuc].append(bounds[i], bounds[1 + i])
 
     for i, (nuc, dominance) in enumerate(zip(dominant_nucs, relative_max)):
         ax.axvspan(
@@ -815,8 +819,10 @@ def plot_single_response(
             ax, shading_color_map, dominance_ranges = shade_dominant_nuclides(
                 shade_piv, ax, shading_color_map, cmap_name=cmap_name
             )
-            for nuc, (tmin, tmax) in dominance_ranges.items():
-                all_dominance_ranges[nuc].append((run_lbl, tmin, tmax))
+
+            for nuc, ranges in dominance_ranges.items():
+                for tmin, tmax in ranges:
+                    all_dominance_ranges[nuc].append((run_lbl, tmin, tmax))
 
         for nuc in piv.index:
             if nuc == 'total' and not total:
@@ -845,10 +851,15 @@ def plot_single_response(
                         f'\\ \\sigma = {y.std():.{sig_figs}g}$\n――――――'
                     )
 
+            x = piv.columns
+            last_nonzero_time = x[np.flatnonzero(y)[-1]]
+            if last_nonzero_time > xmax:
+                xmax = last_nonzero_time
+
             plot_or_scatter(
                 ax=ax,
                 plot_type=plot_type,
-                x=piv.columns,
+                x=x,
                 y=y,
                 label=(nuc + label_suffix),
                 color=color_map[nuc] if nuc != 'total' else "#574949",
@@ -896,6 +907,7 @@ def plot_single_response(
     ax.set_ylabel(ylabel)
     ax.set_xlabel(f'Time ({time_unit})')
     ax.set_xscale('log')
+    ax.set_xlim(right=xmax)
     ax.set_yscale(yscale)
     if ymin:
         ax.set_ylim(bottom=ymin)

--- a/tools/alara_output_processing/alara_output_plotting.py
+++ b/tools/alara_output_processing/alara_output_plotting.py
@@ -774,6 +774,7 @@ def plot_single_response(
         run_lbls = [run_lbls]
 
     data_list = []
+    shade_pivs = {}
     styles = list(
         lines.lineStyles.keys() if plot_type == 'plot'
         else lines.lineMarkers.keys()
@@ -795,22 +796,7 @@ def plot_single_response(
             control_piv = piv
         else:
             data_list.append((run_lbl, filtered, piv, style))
-
-    pivs = [data[2] for data in data_list]
-    color_map = build_color_map(cmap_name=cmap_name, pivs=pivs)
-    thalf_cmap = build_color_map(
-        cmap_name='Reds', pivs=pivs, mark_thalf=mark_thalf
-    )
-
-    plotted_nucs = []
-    xmax = 0
-    all_dominance_ranges = defaultdict(list)
-    shading_color_map = {} if total else color_map
-
-    for run_lbl, filtered, piv, style in data_list:
-        if shading:
-            shade_piv = piv
-            if total:
+            if shading and total:
                 _, shade_piv = preprocess_data(
                     adf=adf,
                     run_lbl=run_lbl,
@@ -820,11 +806,33 @@ def plot_single_response(
                     head=head,
                     half_lives=half_lives
                 )
+                shade_pivs[run_lbl] = shade_piv
+            
+            else:
+                shade_piv[run_lbl] = piv
 
-            ax, run_shading_cmap, dominance_ranges = shade_dominant_nuclides(
-                shade_piv, ax, {}, cmap_name=cmap_name
+    pivs = [data[2] for data in data_list]
+    color_map = build_color_map(cmap_name=cmap_name, pivs=pivs)
+    thalf_cmap = build_color_map(
+        cmap_name='Reds', pivs=pivs, mark_thalf=mark_thalf
+    )
+
+    shading_color_map = {}
+    if shading:
+        shading_color_map = build_color_map(
+            cmap_name=cmap_name, pivs=list(shade_pivs.values())
+        )
+
+    plotted_nucs = []
+    xmax = 0
+    all_dominance_ranges = defaultdict(list)
+
+    for run_lbl, filtered, piv, style in data_list:
+        if shading:
+            ax, _, dominance_ranges = shade_dominant_nuclides(
+                shade_pivs[run_lbl], ax,
+                shading_color_map, cmap_name=cmap_name
             )
-            shading_color_map.update(run_shading_cmap)
 
             for nuc, ranges in dominance_ranges.items():
                 for tmin, tmax in ranges:

--- a/tools/alara_output_processing/alara_output_plotting.py
+++ b/tools/alara_output_processing/alara_output_plotting.py
@@ -586,7 +586,7 @@ def shade_dominant_nuclides(piv, ax, color_map, cmap_name):
 
     return ax, bounds, dominant_nucs
 
-def collect_shading_labels(ax, color_map, all_dominance_ranges, time_unit):
+def add_shading_legend_labels(ax, color_map, all_dominance_ranges, time_unit):
     '''
     Unpack and format dominant nuclide data produced from 
         shade_dominant_nuclides() to be included in a plot's legend in the
@@ -623,6 +623,7 @@ def collect_shading_labels(ax, color_map, all_dominance_ranges, time_unit):
             f'   -  {rl}: {tmin:.2g} - {tmax:.2g} {time_unit}'
             for rl, tmin, tmax in run_entries
         )
+        # Zero-width spans for legend purposes only -- not visible on plot fig
         ax.axvspan(
             0,
             0,
@@ -817,11 +818,20 @@ def plot_single_response(
 
             for nuc in set(dominant_nucs):
                 indices = [i for i, n in enumerate(dominant_nucs) if n == nuc]
-                all_dominance_ranges[nuc].append((
-                    run_lbl,
-                    bounds[indices[0]],     # t_min
-                    bounds[indices[-1] + 1] # t_max
-                ))
+                contiguous_ranges = []
+                range_start = indices[0]
+                for prev, curr in zip(indices, indices[1:]):
+                    if curr != prev + 1:
+                        contiguous_ranges.append(range_start, prev)
+                        range_start = curr
+                contiguous_ranges.append((range_start, indices[-1]))
+
+                for lower, upper in contiguous_ranges:
+                    all_dominance_ranges[nuc].append((
+                        run_lbl,
+                        bounds[lower],
+                        bounds[upper + 1]
+                    ))
 
         for nuc in piv.index:
             if nuc == 'total' and not total:
@@ -874,7 +884,7 @@ def plot_single_response(
                 plotted_nucs.append(nuc)
 
     if shading and shading_color_map is not None:
-        collect_shading_labels(
+        add_shading_legend_labels(
             ax, shading_color_map, all_dominance_ranges, time_unit
         )
 

--- a/tools/alara_output_processing/alara_output_plotting.py
+++ b/tools/alara_output_processing/alara_output_plotting.py
@@ -152,6 +152,9 @@ def build_color_map(cmap_name, all_nucs=[], pivs=None, mark_thalf=False):
     if 'Other' in set(all_nucs):
         color_map['Other'] = (0.8, 0.8, 0.8, 1.0)
 
+    if 'total' in set(all_nucs):
+        color_map['total'] = "#574949"
+
     return color_map
 
 def split_label(label):
@@ -806,7 +809,7 @@ def plot_single_response(
         )
 
     plotted_nucs = []
-    xmax = 0
+    tmax = 0
     all_dominance_ranges = defaultdict(list)
 
     for run_lbl, filtered, piv, style in data_list:
@@ -816,22 +819,17 @@ def plot_single_response(
                 shading_color_map, cmap_name=cmap_name
             )
 
-            for nuc in set(dominant_nucs):
-                indices = [i for i, n in enumerate(dominant_nucs) if n == nuc]
-                contiguous_ranges = []
-                range_start = indices[0]
-                for prev, curr in zip(indices, indices[1:]):
-                    if curr != prev + 1:
-                        contiguous_ranges.append(range_start, prev)
-                        range_start = curr
-                contiguous_ranges.append((range_start, indices[-1]))
-
-                for lower, upper in contiguous_ranges:
-                    all_dominance_ranges[nuc].append((
-                        run_lbl,
-                        bounds[lower],
-                        bounds[upper + 1]
+            prev_nuc = dominant_nucs[0]
+            lower = bounds[0]
+            for upper, nuc in zip(bounds[1:], dominant_nucs[1:]):
+                if nuc != prev_nuc:
+                    all_dominance_ranges[prev_nuc].append((
+                        run_lbl, lower, upper
                     ))
+                    lower = upper
+                    prev_nuc = nuc
+
+            all_dominance_ranges[prev_nuc].append((run_lbl, lower, upper))
 
         for nuc in piv.index:
             if nuc == 'total' and not total:
@@ -851,27 +849,27 @@ def plot_single_response(
             # not necessarily an error, as various nuclides may not be present
             # across all cooling times.
 
-            y = piv.loc[nuc].to_numpy()
+            series = piv.loc[nuc].to_numpy()
             if ratio_plotting:
-                y /= control_piv.loc[nuc].to_numpy()
-                if not np.isnan(y.mean()) and nuc == 'total':
+                series /= control_piv.loc[nuc].to_numpy()
+                if not np.isnan(series.mean()) and nuc == 'total':
                     label_suffix += (
-                        f'\n$\\mu = {y.mean():.{sig_figs}g},' \
-                        f'\\ \\sigma = {y.std():.{sig_figs}g}$\n――――――'
+                        f'\n$\\mu = {series.mean():.{sig_figs}g},' \
+                        f'\\ \\sigma = {series.std():.{sig_figs}g}$\n――――――'
                     )
 
-            x = piv.columns
-            last_nonzero_time = x[np.flatnonzero(y)[-1]]
-            if last_nonzero_time > xmax:
-                xmax = last_nonzero_time
+            t = piv.columns
+            last_nonzero_time = t[np.flatnonzero(series)[-1]]
+            if last_nonzero_time > tmax:
+                tmax = last_nonzero_time
 
             plot_or_scatter(
                 ax=ax,
                 plot_type=plot_type,
-                x=x,
-                y=y,
+                x=t,
+                y=series,
                 label=(nuc + label_suffix),
-                color=color_map[nuc] if nuc != 'total' else "#574949",
+                color=color_map[nuc],
                 style=style
             )
 
@@ -916,7 +914,7 @@ def plot_single_response(
     ax.set_ylabel(ylabel)
     ax.set_xlabel(f'Time ({time_unit})')
     ax.set_xscale('log')
-    ax.set_xlim(right=xmax)
+    ax.set_xlim(right=tmax)
     ax.set_yscale(yscale)
     if ymin:
         ax.set_ylim(bottom=ymin)

--- a/tools/alara_output_processing/alara_output_plotting.py
+++ b/tools/alara_output_processing/alara_output_plotting.py
@@ -587,16 +587,21 @@ def shade_dominant_nuclides(piv, ax, color_map, cmap_name):
             dominance_ranges[nuc].append(bounds[i], bounds[1 + i])
 
     for i, (nuc, dominance) in enumerate(zip(dominant_nucs, relative_max)):
-        ax.axvspan(
-            bounds[i],
-            bounds[i + 1],
-            color=color_map[nuc],
-            # Shading transparency as an inverse function of the relative
-            # contribution of the dominant nuclide
-            alpha=0.2 * dominance,
-            linewidth=0,
-            label=None
-        )
+        for rnge in dominance_ranges[nuc]:
+            if np.diff(rnge) > 0:
+                ax.axvspan(
+                    bounds[i],
+                    bounds[i + 1],
+                    color=color_map[nuc],
+                    # Shading transparency as an inverse function of the relative
+                    # contribution of the dominant nuclide
+                    alpha=0.2 * dominance,
+                    linewidth=0,
+                    label=None
+                )
+            else:
+                del dominance_ranges[nuc]
+                del color_map[nuc]
 
     return ax, color_map, dominance_ranges
 
@@ -800,9 +805,9 @@ def plot_single_response(
     plotted_nucs = []
     xmax = 0
     all_dominance_ranges = defaultdict(list)
+    shading_color_map = {} if total else color_map
 
     for run_lbl, filtered, piv, style in data_list:
-        shading_color_map = {} if total else color_map
         if shading:
             shade_piv = piv
             if total:
@@ -816,9 +821,10 @@ def plot_single_response(
                     half_lives=half_lives
                 )
 
-            ax, shading_color_map, dominance_ranges = shade_dominant_nuclides(
-                shade_piv, ax, shading_color_map, cmap_name=cmap_name
+            ax, run_shading_cmap, dominance_ranges = shade_dominant_nuclides(
+                shade_piv, ax, {}, cmap_name=cmap_name
             )
+            shading_color_map.update(run_shading_cmap)
 
             for nuc, ranges in dominance_ranges.items():
                 for tmin, tmax in ranges:

--- a/tools/alara_output_processing/alara_output_plotting.py
+++ b/tools/alara_output_processing/alara_output_plotting.py
@@ -821,7 +821,7 @@ def plot_single_response(
 
             prev_nuc = dominant_nucs[0]
             lower = bounds[0]
-            for upper, nuc in zip(bounds[1:], dominant_nucs[1:]):
+            for upper, nuc in zip(bounds[1:-1], dominant_nucs[1:]):
                 if nuc != prev_nuc:
                     all_dominance_ranges[prev_nuc].append((
                         run_lbl, lower, upper
@@ -829,6 +829,7 @@ def plot_single_response(
                     lower = upper
                     prev_nuc = nuc
 
+            upper = bounds[-1]
             all_dominance_ranges[prev_nuc].append((run_lbl, lower, upper))
 
         for nuc in piv.index:

--- a/tools/alara_output_processing/alara_output_plotting.py
+++ b/tools/alara_output_processing/alara_output_plotting.py
@@ -567,13 +567,10 @@ def shade_dominant_nuclides(piv, ax, color_map, cmap_name):
 
     # Calculate logarithmic half-way values for each cooling time for shading
     # to flow smoothly between nuclide regions
-    logt = np.log10(times)
-    half_delta_logt = 0.5 * np.diff(logt)
-    log_bounds = np.empty(len(times) + 1)
-    log_bounds[0] = logt[0] - half_delta_logt[0]
-    log_bounds[1:-1] = logt[:-1] + half_delta_logt
-    log_bounds[-1] = logt[-1] + half_delta_logt[-1]
-    bounds = np.nan_to_num(10**log_bounds, nan=0.0)
+    bounds = np.empty(len(times) + 1)
+    bounds[1:-1] = np.sqrt(times[1:] * times[:-1])
+    bounds[0] = times[0] * times[0] / bounds[1]
+    bounds[-1] = times[-1] * times[-1] / bounds[-2]
 
     # Calculate the time bounds for each dominant nuclide's period of leading
     # contribution to the response variable

--- a/tools/alara_output_processing/alara_output_plotting.py
+++ b/tools/alara_output_processing/alara_output_plotting.py
@@ -540,13 +540,10 @@ def shade_dominant_nuclides(piv, ax, color_map, cmap_name):
     Returns:
         ax (matplotlib.axes._axes.Axes): Updated Axes object with shaded
             regions for dominant nuclides.
-        color_map (dict): Copy of the original color map dictionary if a non-
-            empty dictionary is provided in the Arguments. Otherwise, a color
-            map with keys only of the various dominant nuclides.
-        dominance_ranges (dict): Dictionary keyed by each nuclide that is the
-            predominant contributor the input pivot table's decay response at
-            some time. Values are lists of all cooling times in which that
-            nuclide is the dominant contributor.
+        bounds (numpy.ndarray): Logarithmic half-way values between cooling
+            times to bound axvspan shading regions.
+        dominant_nucs (list of str): List of the dominant nuclide in each
+            logarithmically bounded region.
     '''
 
     total_piv = piv[piv.index == 'total']
@@ -573,31 +570,21 @@ def shade_dominant_nuclides(piv, ax, color_map, cmap_name):
     bounds[-1] = times[-1] * times[-1] / bounds[-2]
     bounds = np.nan_to_num(bounds, nan=0.0)
 
-    # Calculate the time bounds for each dominant nuclide's period of leading
-    # contribution to the response variable
-    dominance_ranges = {}
-    for i, nuc in enumerate(dominant_nucs):
-        if nuc not in dominance_ranges:
-            dominance_ranges[nuc] = [[bounds[i], bounds[i + 1]]]
-        elif dominance_ranges[nuc][-1][1] == bounds[i]:
-            dominance_ranges[nuc][-1][1] = bounds[i + 1]
-        else:
-            dominance_ranges[nuc].append([bounds[i], bounds[1 + i]])
+    for lower, upper, nuc, dominance, in zip(
+        bounds[:-1], bounds[1:], dominant_nucs, relative_max
+    ):
+        ax.axvspan(
+            lower,
+            upper,
+            color=color_map[nuc],
+            # Shading transparency as an inverse function of the relative
+            # contribution of the dominant nuclide
+            alpha=0.2 * dominance,
+            linewidth=0,
+            label=None
+        )
 
-    for i, (nuc, dominance) in enumerate(zip(dominant_nucs, relative_max)):
-        for _ in dominance_ranges[nuc]:
-            ax.axvspan(
-                bounds[i],
-                bounds[i + 1],
-                color=color_map[nuc],
-                # Shading transparency as an inverse function of the relative
-                # contribution of the dominant nuclide
-                alpha=0.2 * dominance,
-                linewidth=0,
-                label=None
-            )
-
-    return ax, color_map, dominance_ranges
+    return ax, bounds, dominant_nucs
 
 def collect_shading_labels(ax, color_map, all_dominance_ranges, time_unit):
     '''
@@ -823,14 +810,18 @@ def plot_single_response(
 
     for run_lbl, filtered, piv, style in data_list:
         if shading:
-            ax, _, dominance_ranges = shade_dominant_nuclides(
+            ax, bounds, dominant_nucs = shade_dominant_nuclides(
                 shade_pivs[run_lbl], ax,
                 shading_color_map, cmap_name=cmap_name
             )
 
-            for nuc, ranges in dominance_ranges.items():
-                for tmin, tmax in ranges:
-                    all_dominance_ranges[nuc].append((run_lbl, tmin, tmax))
+            for nuc in set(dominant_nucs):
+                indices = [i for i, n in enumerate(dominant_nucs) if n == nuc]
+                all_dominance_ranges[nuc].append((
+                    run_lbl,
+                    bounds[indices[0]],     # t_min
+                    bounds[indices[-1] + 1] # t_max
+                ))
 
         for nuc in piv.index:
             if nuc == 'total' and not total:

--- a/tools/alara_output_processing/alara_output_plotting.py
+++ b/tools/alara_output_processing/alara_output_plotting.py
@@ -597,7 +597,6 @@ def shade_dominant_nuclides(piv, ax, color_map, cmap_name):
                 label=None
             )
 
-
     return ax, color_map, dominance_ranges
 
 def collect_shading_labels(ax, color_map, all_dominance_ranges, time_unit):

--- a/tools/alara_output_processing/alara_output_plotting.py
+++ b/tools/alara_output_processing/alara_output_plotting.py
@@ -249,6 +249,10 @@ def construct_legend(ax, legend_ax=None):
         grouped_labels.append(f'{isotope} {datalib}')
         prev_isotope = isotope
 
+    # Remove final line separator, which could have been applied above or in
+    # total statistics calculation
+    grouped_labels[-1] = grouped_labels[-1].replace('――――――', '')
+
     if legend_ax:
         target_ax = legend_ax
         loc = 'center'

--- a/tools/alara_output_processing/alara_output_plotting.py
+++ b/tools/alara_output_processing/alara_output_plotting.py
@@ -5,6 +5,7 @@ from matplotlib import lines
 import matplotlib.cm as cm
 from warnings import warn
 import alara_output_processing as aop
+from collections import defaultdict
 
 # ------- Utility and Helper Functions -------
 
@@ -195,13 +196,18 @@ def reformat_isotope(isotope):
             ᴬelement.
     '''
 
+    time_bounds = ''
+    if ':' in isotope:
+        isotope, time_bounds = isotope.split(':', 1)
+        time_bounds = ':' + time_bounds
+
     if 'total' in isotope.lower() or isotope == 'Other':
         return isotope
-    
+
     else:
         element, A = isotope.split('-')
         element = element.capitalize()
-        return f'$^{{{A}}}${element}'
+        return f'$^{{{A}}}${element}{time_bounds}'
 
 def construct_legend(ax, data_comp=False, legend_ax=None):
     '''
@@ -511,6 +517,131 @@ def add_pie(ax, time_slice, color_map, threshold):
 
     return wedges
 
+def shade_dominant_nuclides(piv, ax, color_map, cmap_name):
+    '''
+    Identify the time ranges for a single response variable in which any
+        individual nuclide is the response's dominant contributor. Over these
+        ranges, shade the region with a corresponding color for that nuclide,
+        either with a pre-existing color map or by producing a new one if not
+        provided. Shading is done as a function of the proportion of the total
+        decay response contributed by the dominant nuclide at each time, with
+        proportions closer to 1 being shaded darker and vice versa.
+
+    Arguments:
+        piv (pandas.DataFrame): Pivot table indexed by nuclides with values
+            for each cooling time.
+        ax (matplotlib.axes._axes.Axes): Matplotlib Axes object of the plot
+            being constructed.
+        color_map (dict): Pre-constructed color map for each nuclide to match
+            the wedges with the legend. Empty dictionary if no color map
+            existing yet for the plot.
+        cmap_name (str): Matplotlib Colormap for the plot.
+
+    Returns:
+        ax (matplotlib.axes._axes.Axes): Updated Axes object with shaded
+            regions for dominant nuclides.
+        color_map (dict): Copy of the original color map dictionary if a non-
+            empty dictionary is provided in the Arguments. Otherwise, a color
+            map with keys only of the various dominant nuclides.
+        dominance_ranges (dict): Dictionary keyed by each nuclide that is the
+            predominant contributor the input pivot table's decay response at
+            some time. Values are lists of all cooling times in which that
+            nuclide is the dominant contributor.
+    '''
+
+    total_piv = piv[piv.index == 'total']
+    piv = piv[piv.index != 'total']
+    dominant_nucs = [piv[t].idxmax() for t in piv.columns]
+    relative_max = np.array([piv[t].max() for t in piv.columns])
+    times = np.asarray(piv.columns, dtype=float)
+    
+    # Calculate relative contribution of the dominant nuclide for a pivot
+    # table containing absolute, rather than relative values
+    if not total_piv.empty:
+        relative_max /= total_piv.T['total'].values
+
+    if not color_map:
+        color_map = build_color_map(
+            cmap_name=cmap_name, all_nucs=set(dominant_nucs)
+        )
+
+    # Calculate logarithmic half-way values for each cooling time for shading
+    # to flow smoothly between nuclide regions
+    logt = np.log10(times)
+    bounds = np.empty(len(times) + 1)
+    bounds[1:-1] = 10 ** ((logt[:-1] + logt[1:]) / 2)
+    bounds[0]    = 10 ** (logt[0] - (logt[1] - logt[0]) / 2)
+    bounds[-1]   = 10 ** (logt[-1] + (logt[-1] - logt[-2]) / 2)
+
+    # Calculate the time bounds for each dominant nuclide's period of leading
+    # contribution to the response variable
+    dominance_ranges = {}
+    for i, nuc in enumerate(dominant_nucs):
+        if nuc not in dominance_ranges:
+            dominance_ranges[nuc] = [bounds[i], bounds[i + 1]]
+        else:
+            dominance_ranges[nuc][1] = bounds[i + 1]
+
+    for i, (nuc, dominance) in enumerate(zip(dominant_nucs, relative_max)):
+        ax.axvspan(
+            bounds[i],
+            bounds[i + 1],
+            color=color_map[nuc],
+            # Shading transparency as an inverse function of the relative
+            # contribution of the dominant nuclide
+            alpha=0.2 * dominance,
+            linewidth=0,
+            label=None
+        )
+
+    return ax, color_map, dominance_ranges
+
+def collect_shading_labels(ax, color_map, all_dominance_ranges, time_unit):
+    '''
+    Unpack and format dominant nuclide data produced from 
+        shade_dominant_nuclides() to be included in a plot's legend in the
+        format:
+
+            nuclide:
+                run_lbl: beginning_of_dominance_range - end_of_dominance_range
+
+    Arguments:
+        ax (matplotlib.axes._axes.Axes): Updated Axes object with shaded
+            regions for dominant nuclides.
+        color_map (dict): Copy of the original color map dictionary if a non-
+            empty dictionary is provided in the Arguments. Otherwise, a color
+            map with keys only of the various dominant nuclides.
+        all_dominance_ranges (dict): Dictionary keyed by nuclides that are the
+            dominant contributor to a decay response over some time time range
+            formatted as:
+
+                {
+                    nuclide: 
+                        (
+                            run_lbl,
+                            beginning_of_dominance_range,
+                            end_of_dominance_range
+                        )
+                }
+
+    Returns:
+        None 
+    '''
+
+    for nuc, run_entries in all_dominance_ranges.items():
+        run_lines = '\n'.join(
+            f'   -  {rl}: {tmin:.2g} - {tmax:.2g} {time_unit}'
+            for rl, tmin, tmax in run_entries
+        )
+        ax.axvspan(
+            0,
+            0,
+            color=color_map[nuc],
+            alpha=0.6,
+            linewidth=0,
+            label = f'{nuc}:\n{run_lines}'
+        )
+
 # ----- Plotting Functions ------
 
 def plot_single_response(
@@ -531,7 +662,8 @@ def plot_single_response(
     separate_legend=False,
     control_run=None,
     sig_figs=3,
-    mark_thalf=False
+    mark_thalf=False,
+    shading=False
 ):
     '''
     Create a simple x-y plot of a given variable tracked in an ALARA output
@@ -610,6 +742,10 @@ def plot_single_response(
         mark_thalf (bool, optional): Option to mark a vertical line for the
             half-lives of all nuclides present in the plot.
             (Defaults to False)
+        shading (bool, optional): Option to shade the regions in which any
+            particular nuclide is the dominant contributor to the plotted
+            decay response.
+            (Defaults to False)
 
     Returns:
         fig (matplotlib.figure.Figure): Closed Matplotlib Figure object
@@ -658,7 +794,30 @@ def plot_single_response(
     )
 
     plotted_nucs = []
+    xmax = 0
+    all_dominance_ranges = defaultdict(list)
+
     for run_lbl, filtered, piv, style in data_list:
+        shading_color_map = {} if total else color_map
+        if shading:
+            shade_piv = piv
+            if total:
+                _, shade_piv = preprocess_data(
+                    adf=adf,
+                    run_lbl=run_lbl,
+                    variable=variable,
+                    time_unit=time_unit,
+                    sort_by_time=sort_by_time,
+                    head=head,
+                    half_lives=half_lives
+                )
+
+            ax, shading_color_map, dominance_ranges = shade_dominant_nuclides(
+                shade_piv, ax, shading_color_map, cmap_name=cmap_name
+            )
+            for nuc, (tmin, tmax) in dominance_ranges.items():
+                all_dominance_ranges[nuc].append((run_lbl, tmin, tmax))
+
         for nuc in piv.index:
             if nuc == 'total' and not total:
                 continue
@@ -692,16 +851,22 @@ def plot_single_response(
                 x=piv.columns,
                 y=y,
                 label=(nuc + label_suffix),
-                color=color_map[nuc],
+                color=color_map[nuc] if nuc != 'total' else "#574949",
                 style=style
             )
 
             if mark_thalf and nuc not in plotted_nucs:
                 thalf = filtered.get_thalf(nuc)
-                plt.axvline(x=thalf, color=thalf_cmap[nuc], alpha=0.85, label=(
+                plt.axvline(
+                    x=thalf, color=thalf_cmap[nuc], alpha=0.85, label=(
                     rf'{nuc} ($t_{{1/2}} = {thalf:.2e}{time_unit}$)'
                 ))
                 plotted_nucs.append(nuc)
+
+    if shading and shading_color_map is not None:
+        collect_shading_labels(
+            ax, shading_color_map, all_dominance_ranges, time_unit
+        )
 
     ylabel = f'{variable} [{filtered['var_unit'].unique()[0]}]'
     title_suffix = (

--- a/tools/alara_output_processing/alara_output_plotting.py
+++ b/tools/alara_output_processing/alara_output_plotting.py
@@ -212,7 +212,7 @@ def reformat_isotope(isotope):
         element = element.capitalize()
         return f'$^{{{A}}}${element}{time_bounds}'
 
-def construct_legend(ax, data_comp=False, legend_ax=None):
+def construct_legend(ax, legend_ax=None):
     '''
     Create a custom pyplot legend that exists outside of the grid itself and
         can group like-isotopes together from compared data sets for clarity.
@@ -220,9 +220,6 @@ def construct_legend(ax, data_comp=False, legend_ax=None):
     Arguments:
         ax (matplotlib.axes._axes.Axes): Matplotlib Axes object of the plot
             being constructed.
-        data_comp (bool, optional): Boolean setting for comparison between two
-            data sets.
-            (Defaults to False)
         legend_ax (matplotlib.axes._axes.Axes or None, optional): Optional
             argument to construct the legend on a separate Matplotlib Axes
             object than the plot itself.
@@ -233,12 +230,9 @@ def construct_legend(ax, data_comp=False, legend_ax=None):
     '''
 
     handles, labels = ax.get_legend_handles_labels()
-    labels_sorted_with_handles = sorted(
-        zip(labels, handles),
-        key=lambda x: (
-            split_label(x[0]) if data_comp else (split_label(x[0])[0], x[0])
-        )
-    )
+    labels_sorted_with_handles = sorted(zip(labels, handles), key=lambda x: (
+        (s := split_label(x[0]))[0].lower().startswith('total'), s[0], s[1]
+    ))
 
     grouped_handles = []
     grouped_labels = []
@@ -933,7 +927,7 @@ def plot_single_response(
         _, legend_ax = plt.subplots(figsize=(4, max(4, 0.3 * n_items)))
         legend_ax.axis('off')
 
-    legend_fig = construct_legend(ax, data_comp, legend_ax)
+    legend_fig = construct_legend(ax, legend_ax)
 
     ax.grid(True)
     plt.tight_layout(rect=[0, 0, 0.85, 1])

--- a/tools/alara_output_processing/alara_output_plotting.py
+++ b/tools/alara_output_processing/alara_output_plotting.py
@@ -518,7 +518,7 @@ def add_pie(ax, time_slice, color_map, threshold):
 
     return wedges
 
-def shade_dominant_nuclides(piv, ax, color_map, cmap_name):
+def shade_dominant_nuclides(piv, ax, color_map, cmap_name, n_runs):
     '''
     Identify the time ranges for a single response variable in which any
         individual nuclide is the response's dominant contributor. Over these
@@ -537,6 +537,7 @@ def shade_dominant_nuclides(piv, ax, color_map, cmap_name):
             the wedges with the legend. Empty dictionary if no color map
             existing yet for the plot.
         cmap_name (str): Matplotlib Colormap for the plot.
+        n_runs (int): Number of runs being comparatively plotted.
 
     Returns:
         ax (matplotlib.axes._axes.Axes): Updated Axes object with shaded
@@ -579,8 +580,9 @@ def shade_dominant_nuclides(piv, ax, color_map, cmap_name):
             upper,
             color=color_map[nuc],
             # Shading transparency as an inverse function of the relative
-            # contribution of the dominant nuclide
-            alpha=0.2 * dominance,
+            # contribution of the dominant nuclide and scaled by the number
+            # of runs being compared
+            alpha=(0.2 * dominance) / (n_runs * 0.5),
             linewidth=0,
             label=None
         )
@@ -820,8 +822,8 @@ def plot_single_response(
     for run_lbl, filtered, piv, style in data_list:
         if shading:
             ax, bounds, dominant_nucs = shade_dominant_nuclides(
-                shade_pivs[run_lbl], ax,
-                shading_color_map, cmap_name=cmap_name
+                shade_pivs[run_lbl], ax, shading_color_map,
+                cmap_name=cmap_name, n_runs=len(data_list)
             )
 
             prev_nuc = dominant_nucs[0]

--- a/tools/alara_output_processing/alara_output_plotting.py
+++ b/tools/alara_output_processing/alara_output_plotting.py
@@ -571,6 +571,7 @@ def shade_dominant_nuclides(piv, ax, color_map, cmap_name):
     bounds[1:-1] = np.sqrt(times[1:] * times[:-1])
     bounds[0] = times[0] * times[0] / bounds[1]
     bounds[-1] = times[-1] * times[-1] / bounds[-2]
+    bounds = np.nan_to_num(bounds, nan=0.0)
 
     # Calculate the time bounds for each dominant nuclide's period of leading
     # contribution to the response variable
@@ -581,24 +582,21 @@ def shade_dominant_nuclides(piv, ax, color_map, cmap_name):
         elif dominance_ranges[nuc][-1][1] == bounds[i]:
             dominance_ranges[nuc][-1][1] = bounds[i + 1]
         else:
-            dominance_ranges[nuc].append(bounds[i], bounds[1 + i])
+            dominance_ranges[nuc].append([bounds[i], bounds[1 + i]])
 
     for i, (nuc, dominance) in enumerate(zip(dominant_nucs, relative_max)):
-        for rnge in dominance_ranges[nuc]:
-            if np.diff(rnge) > 0:
-                ax.axvspan(
-                    bounds[i],
-                    bounds[i + 1],
-                    color=color_map[nuc],
-                    # Shading transparency as an inverse function of the relative
-                    # contribution of the dominant nuclide
-                    alpha=0.2 * dominance,
-                    linewidth=0,
-                    label=None
-                )
-            else:
-                del dominance_ranges[nuc]
-                del color_map[nuc]
+        for _ in dominance_ranges[nuc]:
+            ax.axvspan(
+                bounds[i],
+                bounds[i + 1],
+                color=color_map[nuc],
+                # Shading transparency as an inverse function of the relative
+                # contribution of the dominant nuclide
+                alpha=0.2 * dominance,
+                linewidth=0,
+                label=None
+            )
+
 
     return ax, color_map, dominance_ranges
 

--- a/tools/alara_output_processing/alara_output_plotting.py
+++ b/tools/alara_output_processing/alara_output_plotting.py
@@ -809,7 +809,7 @@ def plot_single_response(
                 shade_pivs[run_lbl] = shade_piv
             
             else:
-                shade_piv[run_lbl] = piv
+                shade_pivs[run_lbl] = piv
 
     pivs = [data[2] for data in data_list]
     color_map = build_color_map(cmap_name=cmap_name, pivs=pivs)


### PR DESCRIPTION
This PR introduces new functionality to `tools/alara_output_processing/alara_output_plotting.plot_single_response()` to shade regions of a decay response vs time plot to indicate the dominant nuclide contributor at those times and the relative dominance of said contribution. An example for the comparison of the Total Specific Activity vs Time for the irradiation of elemental iron between ALARA with TENDL-2017 cross-sections, ALARA with EAF-2010 cross-sections, and FISPACT-II with TENDL-2017 cross-sections looks like this:

<img width="855" height="573" alt="image" src="https://github.com/user-attachments/assets/cd4b7ea5-3452-461c-b3bf-38eb3bf1ceef" />
<img width="349" height="379" alt="image" src="https://github.com/user-attachments/assets/afe960a3-5230-4d34-90e4-8f6d1b177283" />


The darkness of the shading of a region corresponds to the proportion of the total response contributed by the dominant nuclide, with a higher proportion leading to a less transparent shading. Furthermore, if multiple runs are plotted comparatively, the shading is cumulative, so darker regions can also indicate agreement between runs.

I figured an addition like this would be helpful to include in our plotting module, especially to make "total" plots more informative in showing which nuclides are most prominent across cooling times.