### PR TITLE
Handling TENDL-2014 processing errors in ALARAJOYWrapper

### DIFF
--- a/tools/ALARAJOYWrapper/njoy_tools.py
+++ b/tools/ALARAJOYWrapper/njoy_tools.py
@@ -572,7 +572,7 @@ def ensure_gendf_markers(gendf_path, matb):
     with open(gendf_path, 'w') as gendf_file:
         gendf_file.write(file_str)
 
-def run_njoy(element, A, matb, file_capture, timeout=None):
+def run_njoy(element, A, matb, file_capture, tendl_dir, timeout=None):
     """
     Use subprocess to run NJOY given a pre-written input card to either
         prepare, format, and produce a PENDF file with NJOY modules RECONR,
@@ -590,6 +590,8 @@ def run_njoy(element, A, matb, file_capture, timeout=None):
         matb (int): Unique material ID for the material in the files.
         file_capture (str): Type of file to be saved from this particular 
             iteration of NJOY runs. Either "PENDF" or "GENDF".
+        tendl_dir (pathlib._local.PosixPath): Path to the directory in which
+            the original TENDL nuclide files are contained.
         timeout (None or int): Runtime limit for NJOY run.
             (Defaults to None)
     
@@ -627,7 +629,7 @@ def run_njoy(element, A, matb, file_capture, timeout=None):
     if not result.stderr:
         save_path = dir / fileinfo['dir']
         save_path.mkdir(exist_ok=True)
-        save_path = save_path / f'tendl_2017_{element}{str(A).zfill(3)}'
+        save_path = save_path / f'{tendl_dir}_{element}{str(A).zfill(3)}'
 
         fileinfo['save'] = save_path.with_suffix(fileinfo['ext'])
         tape_save = Path(f'tape{fileinfo['tape']}')

--- a/tools/ALARAJOYWrapper/njoy_tools.py
+++ b/tools/ALARAJOYWrapper/njoy_tools.py
@@ -72,6 +72,17 @@ stop
     MATD = 0,                                # next mat number to be processed
 ))
 
+gaspr_input = Template(Template(
+"""
+gaspr
+ $NENDF $npend_gaspr $NOUT_gaspr/
+stop
+"""
+).safe_substitute(
+    NENDF = 21,                # unit for endf tape (equivalent to NOUT_moder)
+    NOUT_gaspr = 25,                      # unit for GASPR-produced pendf tape
+))
+
 groupr_input = Template(Template(
 """
 groupr/
@@ -355,7 +366,7 @@ def card9_special_isomer_reactions(pKZA, MT, mt_data, isomer_data, mtname):
 
 def fill_input_template(
     inp, material_id, MTs, element, A, mt_dict, temperature,
-    pKZA=None, isomer_dict={}, ign=17, ngn='', egn=''
+    pKZA=None, isomer_dict={}, unresr_fail=False, ign=17, ngn='', egn=''
 ):
     """
     Substitute in the material-specific values for a given ENDF/PENDF file
@@ -388,6 +399,10 @@ def fill_input_template(
             states of the residual daughter. Only needed when filling the
             GROUPR-specific template.
             (Defaults to {})
+        unresr_fail (bool, optional): Boolean flag to indicate if the UNRESR
+            module raised an ***error in rdunf2*** message (see NJOY module
+            section 5.6 for further description of UNRESR errors).
+            (Defaults to False)
         ign (str or int, optional): GROUPR neutron group structure parameter.
             ign = 1 for arbitrary group structures not contained in NJOY's
             built-in list of options. Default value corresponds to ign key for
@@ -437,6 +452,13 @@ def fill_input_template(
                 card9_lines.append(f'{MFD} {MT} "{mtname}" /')
 
     card9 = '\n '.join(card9_lines)
+    
+    # Set GASPR PENDF input. If UNRESR fails, apply the previous PENDF tape
+    # for GASPR input
+    npend_gaspr = 24
+    if unresr_fail:
+        npend_gaspr -= 1
+
     return inp.substitute(
         element=element,
         a=A,
@@ -449,6 +471,7 @@ def fill_input_template(
         ngn=ngn,
         egn=egn,                     
         reactions=card9,                                        
+        npend_gaspr=npend_gaspr
     )
 
 def write_njoy_input_file(template):
@@ -569,7 +592,8 @@ def run_njoy(element, A, matb, file_capture):
                                     File path to the newly created GENDF file.
                                     Returns None if NJOY runs unsuccessfuly.
         result.stderr (str or None): Output of NJOY error.
-                                    Returns None if NJOY runs successfully. 
+                                    Returns None if NJOY runs successfully.
+        result.stdout (str): NJOY standard output.
     """
 
     file_metadata = {
@@ -599,7 +623,7 @@ def run_njoy(element, A, matb, file_capture):
         if fileinfo['ext'] == '.gendf':
             ensure_gendf_markers(fileinfo['save'], matb)
             
-    return fileinfo['save'], result.stderr
+    return fileinfo['save'], result.stderr, result.stdout
 
 def copy_energy_groups_from_njoy_output(
     group_name, nGroups, groupr_output='output'

--- a/tools/ALARAJOYWrapper/njoy_tools.py
+++ b/tools/ALARAJOYWrapper/njoy_tools.py
@@ -34,7 +34,7 @@ reconr
  $NENDF $NPEND_reconr/
  $title
  $mat_id/
- $ERR/
+ $err/
  $MATD/
 broadr
  $NENDF $NPEND_reconr $NPEND_broadr/
@@ -57,7 +57,6 @@ stop
     NOUT_moder = 21,                                       # MODER output unit
     NENDF = 21,                # unit for endf tape (equivalent to NOUT_moder)
     NPEND_reconr = 22,                   # unit for RECONR-produced pendf tape
-    ERR = 0.001,                         # fractional reconstruction tolerance
     NPEND_broadr = 23,                   # unit for BROADR-produced pendf tape
     N_FINAL_TEMPS = 1,            # number of final temperatures (default = 1)
     ERRTHN = 0.001,                        # fractional tolerance for thinning
@@ -366,7 +365,8 @@ def card9_special_isomer_reactions(pKZA, MT, mt_data, isomer_data, mtname):
 
 def fill_input_template(
     inp, material_id, MTs, element, A, mt_dict, temperature,
-    pKZA=None, isomer_dict={}, unresr_fail=False, ign=17, ngn='', egn=''
+    pKZA=None, isomer_dict={}, unresr_fail=False, err=0.001,
+    ign=17, ngn='', egn=''
 ):
     """
     Substitute in the material-specific values for a given ENDF/PENDF file
@@ -403,6 +403,9 @@ def fill_input_template(
             module raised an ***error in rdunf2*** message (see NJOY module
             section 5.6 for further description of UNRESR errors).
             (Defaults to False)
+        err (float, optional): Option to set the RECONR fractional error
+            tolerance.
+            (Defaults to 0.001)
         ign (str or int, optional): GROUPR neutron group structure parameter.
             ign = 1 for arbitrary group structures not contained in NJOY's
             built-in list of options. Default value corresponds to ign key for
@@ -414,7 +417,7 @@ def fill_input_template(
         egn (str): Space-joined string of all energy group bounds in ascending
             order. Will be an empty string unless ign == 1.
             (Defaults to '')
-    
+
     Returns:
         template (str): Modified template with the material-
             specific information substituted in for the $identifiers,
@@ -471,7 +474,8 @@ def fill_input_template(
         ngn=ngn,
         egn=egn,                     
         reactions=card9,                                        
-        npend_gaspr=npend_gaspr
+        npend_gaspr=npend_gaspr,
+        err=err
     )
 
 def write_njoy_input_file(template):
@@ -568,7 +572,7 @@ def ensure_gendf_markers(gendf_path, matb):
     with open(gendf_path, 'w') as gendf_file:
         gendf_file.write(file_str)
 
-def run_njoy(element, A, matb, file_capture):
+def run_njoy(element, A, matb, file_capture, timeout=None):
     """
     Use subprocess to run NJOY given a pre-written input card to either
         prepare, format, and produce a PENDF file with NJOY modules RECONR,
@@ -586,6 +590,8 @@ def run_njoy(element, A, matb, file_capture):
         matb (int): Unique material ID for the material in the files.
         file_capture (str): Type of file to be saved from this particular 
             iteration of NJOY runs. Either "PENDF" or "GENDF".
+        timeout (None or int): Runtime limit for NJOY run.
+            (Defaults to None)
     
     Returns:
         file_info['save'] (pathlib._local.PosixPath or None):
@@ -602,10 +608,16 @@ def run_njoy(element, A, matb, file_capture):
     }
 
     # Run NJOY
-    with open(INPUT, 'r') as f:
+    try:
         result = subprocess.run(
-            ['njoy'], stdin=f, text=True, capture_output=True
+            ['njoy'],
+            input=open(INPUT).read(),
+            text=True,
+            capture_output=True,
+            timeout=timeout
         )
+    except subprocess.TimeoutExpired as te:
+        return None, te, None
 
     fileinfo = file_metadata[file_capture]
     fileinfo['save'] = None

--- a/tools/ALARAJOYWrapper/preprocess_fendl3.py
+++ b/tools/ALARAJOYWrapper/preprocess_fendl3.py
@@ -113,9 +113,7 @@ def configure_logging(redirect_warnings=False):
 
     logger.addHandler(console_handler)
 
-def process_pendf(
-    njoy_prep_input, material_id, MTs, pKZA, mt_dict, temperature, tendl_path
-):
+def process_pendf(material_id, MTs, pKZA, mt_dict, temperature, tendl_path):
     """
     Prepare and run initial NJOY run with MODER, RECONR, BROADR, UNRESR, and
         GASPR modules to prodece the requisite PENDF file for a subsequent
@@ -151,11 +149,36 @@ def process_pendf(
 
     element, A = tp.interpret_KZA(pKZA)
     njoy_error = ''
-    njoy_input = njt.fill_input_template(
-        njoy_prep_input, material_id, MTs, element, A, mt_dict, temperature
+
+    # Run MODER, RECONR, BROADR, UNRESR
+    njoy_prep_input = njt.fill_input_template(
+        njt.njoy_prep_input, material_id, MTs,
+        element, A, mt_dict, temperature
     )
-    njt.write_njoy_input_file(njoy_input)
-    pendf_path, njoy_error = njt.run_njoy(element, A, material_id, 'PENDF')
+    njt.write_njoy_input_file(njoy_prep_input)
+    pendf_path, prep_error, njoy_out = njt.run_njoy(
+        element, A, material_id, 'PENDF'
+    )
+
+    # If UNRESR fails, run GASPR with PENDF output of BROADR with warning
+    unresr_error_flag = '***error in rdunf2***'
+    if prep_error and unresr_error_flag in njoy_out:
+        warnings.warn(
+            'UNRESR failed to produce cross-sections in the unresolved '\
+            f'energy range for {element}{A}:\n'\
+            f'{njoy_out[njoy_out.find(unresr_error_flag):]}Skipping to GASPR.'
+        )
+        gaspr_input = njt.fill_input_template(
+            njt.gaspr_input, material_id, MTs, element, A,
+            mt_dict, temperature, unresr_fail=True
+        )
+        njt.write_njoy_input_file(gaspr_input)
+        pendf_path, gaspr_error, _ = njt.run_njoy(
+            element, A, material_id, 'PENDF'
+        )
+        njoy_error += gaspr_error
+    else:
+        njoy_error += prep_error
 
     _, pendf_MTs = tp.extract_endf_specs(pendf_path)
     MTs |= pendf_MTs.intersection(set(rxd.GAS_DF['total_mt']))
@@ -228,7 +251,7 @@ def process_gendf(
         ign=ign, ngn=ngn, egn=egn
     )
     njt.write_njoy_input_file(groupr_input)
-    gendf_path, njoy_error = njt.run_njoy(
+    gendf_path, njoy_error, _ = njt.run_njoy(
         element, A, material_id, 'GENDF'
     )
 
@@ -499,19 +522,19 @@ def main():
         element, A, pKZA, endf_path = tuple(file_properties.values())
         TAPE20.write_bytes(endf_path.read_bytes())
 
+        TAPE20.write_bytes(endf_path.read_bytes())
         material_id, MTs = tp.extract_endf_specs(TAPE20)
         endf6_MTs = set(mt_dict)
         if len((MTs - rxd.SPEC_MTS) - endf6_MTs) > 0:
             invalid_MTs = sorted((MTs - rxd.SPEC_MTS) - endf6_MTs)
             warnings.warn(
                 f'Invalid MTs in provided TENDL file for ' \
-                f'{element}-{A}: {invalid_MTs}'
+                f'{element}{A}: {invalid_MTs}'
             )
         MTs = MTs.intersection(endf6_MTs)
 
         MTs, isomer_dict, njoy_prep_error = process_pendf(
-            njt.njoy_prep_input, material_id, MTs,
-            pKZA, mt_dict, temperature, TAPE20
+            material_id, MTs, pKZA, mt_dict, temperature, TAPE20
         )
 
         if not njoy_prep_error:

--- a/tools/ALARAJOYWrapper/preprocess_fendl3.py
+++ b/tools/ALARAJOYWrapper/preprocess_fendl3.py
@@ -10,6 +10,7 @@ import warnings
 import logging
 from pathlib import Path
 from collections import defaultdict
+from subprocess import TimeoutExpired
 
 def make_argparser():
     parser = argparse.ArgumentParser()
@@ -151,14 +152,41 @@ def process_pendf(material_id, MTs, pKZA, mt_dict, temperature, tendl_path):
     njoy_error = ''
 
     # Run MODER, RECONR, BROADR, UNRESR
-    njoy_prep_input = njt.fill_input_template(
-        njt.njoy_prep_input, material_id, MTs,
-        element, A, mt_dict, temperature
-    )
-    njt.write_njoy_input_file(njoy_prep_input)
-    pendf_path, prep_error, njoy_out = njt.run_njoy(
-        element, A, material_id, 'PENDF'
-    )
+    # If fractional error tolerance to low for RECONR, can cause NJOY to time
+    # out. If this occurs, increase error tolerance until NJOY can run
+    # successfully.
+    err = 0.001
+    max_err = 0.02
+    timeouts = [60, 180] # s
+    success = False
+    while err <= max_err and not success:
+        for timeout in timeouts:
+            njoy_prep_input = njt.fill_input_template(
+                njt.njoy_prep_input, material_id, MTs,
+                element, A, mt_dict, temperature, err=err
+            )
+            njt.write_njoy_input_file(njoy_prep_input)
+            pendf_path, prep_error, njoy_out = njt.run_njoy(
+                element, A, material_id, 'PENDF', timeout=timeout
+            )
+
+            if not isinstance(prep_error, TimeoutExpired):
+                success = True
+                break
+    
+        err += 0.001
+
+        print(
+            f'NJOY timed out for {element}{A}. Increasing RECONR fractional '\
+            f'reconstruction tolerance to {err:.3f}.'
+        )
+
+        if err > max_err:
+            warnings.warn(
+                f'NJOY repeatedly timed out for {element}{A} up to err='\
+                f'{max_err:.3f}. Skipping file.'
+            )
+            return set(), dict(), prep_error
 
     # If UNRESR fails, run GASPR with PENDF output of BROADR with warning
     unresr_error_flag = '***error in rdunf2***'

--- a/tools/ALARAJOYWrapper/preprocess_fendl3.py
+++ b/tools/ALARAJOYWrapper/preprocess_fendl3.py
@@ -594,7 +594,7 @@ def main():
         njt.cleanup_njoy_files(element, A)
 
     warnings.warn(
-        f'A total of {unresr_err_count} TENDL files required' \
+        f'A total of {unresr_err_count} TENDL files required ' \
         'an increase in UNRESR fractional error tolerance.'
     )
 

--- a/tools/ALARAJOYWrapper/preprocess_fendl3.py
+++ b/tools/ALARAJOYWrapper/preprocess_fendl3.py
@@ -601,7 +601,7 @@ def main():
     warnings.warn(
         f'A total of {len(unresr_err_cases)} TENDL files required ' \
         'an increase in UNRESR fractional error tolerance for the following' \
-        f'nuclides: {unresr_err_cases}'
+        f' nuclides: {unresr_err_cases}'
     )
 
     # Handle gas total production cross-sections, per user specifications

--- a/tools/ALARAJOYWrapper/preprocess_fendl3.py
+++ b/tools/ALARAJOYWrapper/preprocess_fendl3.py
@@ -116,7 +116,7 @@ def configure_logging(redirect_warnings=False):
 
 def process_pendf(
     material_id, MTs, pKZA, mt_dict, temperature,
-    tendl_path, tendl_dir, unresr_err_count
+    tendl_path, tendl_dir, unresr_err_cases
 ):
     """
     Prepare and run initial NJOY run with MODER, RECONR, BROADR, UNRESR, and
@@ -201,10 +201,10 @@ def process_pendf(
     if prep_error and unresr_error_flag in njoy_out:
         warnings.warn(
             'UNRESR failed to produce cross-sections in the unresolved '\
-            f'energy range for {element}{A}:\n'\
+            f'energy range for {element}-{A}:\n'\
             f'{njoy_out[njoy_out.find(unresr_error_flag):]}Skipping to GASPR.'
         )
-        unresr_err_count += 1
+        unresr_err_cases.append(f'{element}-{A}')
         gaspr_input = njt.fill_input_template(
             njt.gaspr_input, material_id, MTs, element, A,
             mt_dict, temperature, unresr_fail=True
@@ -221,7 +221,7 @@ def process_pendf(
     MTs |= pendf_MTs.intersection(set(rxd.GAS_DF['total_mt']))
     isomer_dict = tp.determine_all_excitations(tendl_path, MTs, pKZA, mt_dict)
 
-    return MTs, isomer_dict, njoy_error, unresr_err_count
+    return MTs, isomer_dict, njoy_error, unresr_err_cases
 
 def process_gendf(
     njoy_groupr_input, material_id, MTs, mt_dict, temperature, pKZA,
@@ -558,7 +558,7 @@ def main():
     eaf_nucs = rxd.find_eaf_ref_data(Path(args.decay_lib[0]))
     all_rxns = defaultdict(lambda: defaultdict(dict))
 
-    unresr_err_count = 0
+    unresr_err_cases = []
     for file_properties in tp.search_for_files(search_dir):
         element, A, pKZA, endf_path = tuple(file_properties.values())
         TAPE20.write_bytes(endf_path.read_bytes())
@@ -573,9 +573,9 @@ def main():
             )
         MTs = MTs.intersection(endf6_MTs)
 
-        MTs, isomer_dict, njoy_prep_error, unresr_err_count = process_pendf(
+        MTs, isomer_dict, njoy_prep_error, unresr_err_cases = process_pendf(
             material_id, MTs, pKZA, mt_dict, temperature,
-            TAPE20, search_dir, unresr_err_count
+            TAPE20, search_dir, unresr_err_cases
         )
 
         if not njoy_prep_error:
@@ -594,8 +594,9 @@ def main():
         njt.cleanup_njoy_files(element, A)
 
     warnings.warn(
-        f'A total of {unresr_err_count} TENDL files required ' \
-        'an increase in UNRESR fractional error tolerance.'
+        f'A total of {len(unresr_err_cases)} TENDL files required ' \
+        'an increase in UNRESR fractional error tolerance for the following' \
+        f'nuclides: {unresr_err_cases}'
     )
 
     # Handle gas total production cross-sections, per user specifications

--- a/tools/ALARAJOYWrapper/preprocess_fendl3.py
+++ b/tools/ALARAJOYWrapper/preprocess_fendl3.py
@@ -138,6 +138,8 @@ def process_pendf(
             unmodified TENDL file.
         tendl_dir (pathlib._local.PosixPath): Path to the directory in which
             the original TENDL nuclide files are contained.
+        unresr_err_cases (list of str): List of all nuclides that required an
+            increase in the fractional error tolerance for UNRESR.
 
     Returns:
         MTs (set): Updated set of all reaction types shared between the
@@ -151,6 +153,9 @@ def process_pendf(
             TENDL file.
         njoy_error (str): Error message from the NJOY run. Empty string if run
             is successful.
+        unresr_err_cases (list of str): Updated list of nuclides that required
+            an increase in the fractional error tolerance for UNRESR, if the
+            given nuclide was so.
     """
 
     element, A = tp.interpret_KZA(pKZA)

--- a/tools/ALARAJOYWrapper/preprocess_fendl3.py
+++ b/tools/ALARAJOYWrapper/preprocess_fendl3.py
@@ -174,6 +174,9 @@ def process_pendf(material_id, MTs, pKZA, mt_dict, temperature, tendl_path):
                 success = True
                 break
     
+        if success:
+            break
+
         err += 0.001
 
         print(

--- a/tools/ALARAJOYWrapper/preprocess_fendl3.py
+++ b/tools/ALARAJOYWrapper/preprocess_fendl3.py
@@ -157,7 +157,7 @@ def process_pendf(material_id, MTs, pKZA, mt_dict, temperature, tendl_path):
     # successfully.
     err = 0.001
     max_err = 0.02
-    timeouts = [60, 180] # s
+    timeouts = [60, 300] # s
     success = False
     while err <= max_err and not success:
         for timeout in timeouts:

--- a/tools/ALARAJOYWrapper/preprocess_fendl3.py
+++ b/tools/ALARAJOYWrapper/preprocess_fendl3.py
@@ -167,24 +167,19 @@ def process_pendf(
     # successfully.
     err = 0.001
     max_err = 0.02
-    timeouts = [60, 300] # s
     success = False
     while err <= max_err and not success:
-        for timeout in timeouts:
-            njoy_prep_input = njt.fill_input_template(
-                njt.njoy_prep_input, material_id, MTs,
-                element, A, mt_dict, temperature, err=err
-            )
-            njt.write_njoy_input_file(njoy_prep_input)
-            pendf_path, prep_error, njoy_out = njt.run_njoy(
-                element, A, material_id, 'PENDF', tendl_dir, timeout=timeout
-            )
+        njoy_prep_input = njt.fill_input_template(
+            njt.njoy_prep_input, material_id, MTs,
+            element, A, mt_dict, temperature, err=err
+        )
+        njt.write_njoy_input_file(njoy_prep_input)
+        pendf_path, prep_error, njoy_out = njt.run_njoy(
+            element, A, material_id, 'PENDF', tendl_dir, timeout=300 # 5 mins
+        )
 
-            if not isinstance(prep_error, TimeoutExpired):
-                success = True
-                break
-    
-        if success:
+        if not isinstance(prep_error, TimeoutExpired):
+            success = True
             break
 
         err += 0.001

--- a/tools/ALARAJOYWrapper/preprocess_fendl3.py
+++ b/tools/ALARAJOYWrapper/preprocess_fendl3.py
@@ -133,6 +133,8 @@ def process_pendf(material_id, MTs, pKZA, mt_dict, temperature, tendl_path):
         temperature (float): Temperature at which to run NJOY modules.
         tendl_path (pathlib._local.PosixPath): Path to the original,
             unmodified TENDL file.
+        tendl_dir (pathlib._local.PosixPath): Path to the directory in which
+            the original TENDL nuclide files are contained.
 
     Returns:
         MTs (set): Updated set of all reaction types shared between the
@@ -167,7 +169,7 @@ def process_pendf(material_id, MTs, pKZA, mt_dict, temperature, tendl_path):
             )
             njt.write_njoy_input_file(njoy_prep_input)
             pendf_path, prep_error, njoy_out = njt.run_njoy(
-                element, A, material_id, 'PENDF', timeout=timeout
+                element, A, material_id, 'PENDF', tendl_dir, timeout=timeout
             )
 
             if not isinstance(prep_error, TimeoutExpired):
@@ -205,7 +207,7 @@ def process_pendf(material_id, MTs, pKZA, mt_dict, temperature, tendl_path):
         )
         njt.write_njoy_input_file(gaspr_input)
         pendf_path, gaspr_error, _ = njt.run_njoy(
-            element, A, material_id, 'PENDF'
+            element, A, material_id, 'PENDF', tendl_dir
         )
         njoy_error += gaspr_error
     else:
@@ -219,7 +221,8 @@ def process_pendf(material_id, MTs, pKZA, mt_dict, temperature, tendl_path):
 
 def process_gendf(
     njoy_groupr_input, material_id, MTs, mt_dict, temperature, pKZA,
-    isomer_dict, all_rxns, eaf_nucs, group_name, ign=17, ngn='', egn=''
+    isomer_dict, all_rxns, eaf_nucs, group_name, tendl_dir,
+    ign=17, ngn='', egn=''
 ):
     """
     Prepare and run NJOY run with GROUPR and iteratively extract cross-section
@@ -258,6 +261,8 @@ def process_gendf(
             decay library, with values of their half-lives.
         group_name (str): Name of the group structure for groupwise
             conversion.
+        tendl_dir (pathlib._local.PosixPath): Path to the directory in which
+            the original TENDL nuclide files are contained.
         ign (str or int, optional): GROUPR neutron group structure parameter.
             ign = 1 for arbitrary group structures not contained in NJOY's
             built-in list of options. Default value corresponds to ign key for
@@ -283,7 +288,7 @@ def process_gendf(
     )
     njt.write_njoy_input_file(groupr_input)
     gendf_path, njoy_error, _ = njt.run_njoy(
-        element, A, material_id, 'GENDF'
+        element, A, material_id, 'GENDF', tendl_dir
     )
 
     if gendf_path:
@@ -564,13 +569,13 @@ def main():
         MTs = MTs.intersection(endf6_MTs)
 
         MTs, isomer_dict, njoy_prep_error = process_pendf(
-            material_id, MTs, pKZA, mt_dict, temperature, TAPE20
+            material_id, MTs, pKZA, mt_dict, temperature, TAPE20, search_dir
         )
 
         if not njoy_prep_error:
             all_rxns, nGroups = process_gendf(
                 njt.groupr_input, material_id, MTs, mt_dict, temperature,
-                pKZA, isomer_dict, all_rxns, eaf_nucs, group_name,
+                pKZA, isomer_dict, all_rxns, eaf_nucs, group_name, search_dir,
                 ign=ign, ngn=ngn, egn=egn
             )
 

--- a/tools/ALARAJOYWrapper/preprocess_fendl3.py
+++ b/tools/ALARAJOYWrapper/preprocess_fendl3.py
@@ -522,7 +522,6 @@ def main():
         element, A, pKZA, endf_path = tuple(file_properties.values())
         TAPE20.write_bytes(endf_path.read_bytes())
 
-        TAPE20.write_bytes(endf_path.read_bytes())
         material_id, MTs = tp.extract_endf_specs(TAPE20)
         endf6_MTs = set(mt_dict)
         if len((MTs - rxd.SPEC_MTS) - endf6_MTs) > 0:

--- a/tools/ALARAJOYWrapper/preprocess_fendl3.py
+++ b/tools/ALARAJOYWrapper/preprocess_fendl3.py
@@ -598,11 +598,12 @@ def main():
 
         njt.cleanup_njoy_files(element, A)
 
-    warnings.warn(
-        f'A total of {len(unresr_err_cases)} TENDL files required ' \
-        'an increase in UNRESR fractional error tolerance for the following' \
-        f' nuclides: {unresr_err_cases}'
-    )
+    if unresr_err_cases:
+        warnings.warn(
+            f'A total of {len(unresr_err_cases)} TENDL files required ' \
+            'an increase in UNRESR fractional error tolerance for the ' \
+            f'following nuclides: {unresr_err_cases}'
+        )
 
     # Handle gas total production cross-sections, per user specifications
     gas_filtered = subtract_gas_from_totals(all_rxns)

--- a/tools/ALARAJOYWrapper/preprocess_fendl3.py
+++ b/tools/ALARAJOYWrapper/preprocess_fendl3.py
@@ -114,7 +114,10 @@ def configure_logging(redirect_warnings=False):
 
     logger.addHandler(console_handler)
 
-def process_pendf(material_id, MTs, pKZA, mt_dict, temperature, tendl_path):
+def process_pendf(
+    material_id, MTs, pKZA, mt_dict, temperature,
+    tendl_path, tendl_dir, unresr_err_count
+):
     """
     Prepare and run initial NJOY run with MODER, RECONR, BROADR, UNRESR, and
         GASPR modules to prodece the requisite PENDF file for a subsequent
@@ -201,6 +204,7 @@ def process_pendf(material_id, MTs, pKZA, mt_dict, temperature, tendl_path):
             f'energy range for {element}{A}:\n'\
             f'{njoy_out[njoy_out.find(unresr_error_flag):]}Skipping to GASPR.'
         )
+        unresr_err_count += 1
         gaspr_input = njt.fill_input_template(
             njt.gaspr_input, material_id, MTs, element, A,
             mt_dict, temperature, unresr_fail=True
@@ -217,7 +221,7 @@ def process_pendf(material_id, MTs, pKZA, mt_dict, temperature, tendl_path):
     MTs |= pendf_MTs.intersection(set(rxd.GAS_DF['total_mt']))
     isomer_dict = tp.determine_all_excitations(tendl_path, MTs, pKZA, mt_dict)
 
-    return MTs, isomer_dict, njoy_error
+    return MTs, isomer_dict, njoy_error, unresr_err_count
 
 def process_gendf(
     njoy_groupr_input, material_id, MTs, mt_dict, temperature, pKZA,
@@ -554,6 +558,7 @@ def main():
     eaf_nucs = rxd.find_eaf_ref_data(Path(args.decay_lib[0]))
     all_rxns = defaultdict(lambda: defaultdict(dict))
 
+    unresr_err_count = 0
     for file_properties in tp.search_for_files(search_dir):
         element, A, pKZA, endf_path = tuple(file_properties.values())
         TAPE20.write_bytes(endf_path.read_bytes())
@@ -568,8 +573,9 @@ def main():
             )
         MTs = MTs.intersection(endf6_MTs)
 
-        MTs, isomer_dict, njoy_prep_error = process_pendf(
-            material_id, MTs, pKZA, mt_dict, temperature, TAPE20, search_dir
+        MTs, isomer_dict, njoy_prep_error, unresr_err_count = process_pendf(
+            material_id, MTs, pKZA, mt_dict, temperature,
+            TAPE20, search_dir, unresr_err_count
         )
 
         if not njoy_prep_error:
@@ -586,6 +592,11 @@ def main():
             )
 
         njt.cleanup_njoy_files(element, A)
+
+    warnings.warn(
+        f'A total of {unresr_err_count} TENDL files required' \
+        'an increase in UNRESR fractional error tolerance.'
+    )
 
     # Handle gas total production cross-sections, per user specifications
     gas_filtered = subtract_gas_from_totals(all_rxns)

--- a/tools/ALARAJOYWrapper/tendl_processing.py
+++ b/tools/ALARAJOYWrapper/tendl_processing.py
@@ -219,11 +219,12 @@ def determine_all_excitations(endf_path, MTs, pKZA, mt_dict):
                 if file and MT in [MT.MT for MT in file.sections]:
                     section = file.section(MT)
                     for line in section.content.split('\n'):
-                        if f' {za} ' in line:
+                        spaced_za = f' {za} '
+                        if spaced_za in line:
                             # Line formatted with ZA cushioned by whitespace
                             # on both sides
                             isomer_dict[MT][MF].append(int(
-                                line.split(za)[1].strip().split(' ')[0]
+                                line.split(spaced_za)[1].strip().split(' ')[0]
                             ))
 
             if not isomer_dict[MT]:


### PR DESCRIPTION
This PR introduces some minor updates for the PENDF production stage of ALARAJOYWrapper to allow for more robust handling in the case of a TENDL file missing necessary energy-dependent data in the unresolved region. The motivation behind this update is that I wanted to produce an ALARAJOY/TENDL-2014 library as well for my analysis, figuring that one possible solution to the question on FISPACT-II/ALARA comparisons that I posed in the discussion in #277 would be to compare ratio plots of FISPACT-II TENDL-2017/TENDL-2014 against ALARA/ALARAJOY TENDL-2017/TENDL-2014 to filter out the impacts of the fundamental differences in the two software's decay chain production. Additionally, while the primary motivation for building ALARAJOYWrapper is to make ALARA compatible specifically with FENDL3.2x (TENDL-2017 cross-sections), it would be undoubtedly valuable if this tool could be used for any TENDL release. 

When running ALARAJOYWrapper with the [TENDL-2014 distribution from IAEA](https://www-nds.iaea.org/public/download-endf/TENDL-2014/n/), I ran into two issues. First, for a few files, UNRESR was failing with this NJOY error message:

```
***error in rdunf2***energy dependent data undefined
                      between  8.9001E+03 and  8.9001E+03 eV
```

This message indicates a deprecation of the data as the NJOY manual describes in section 5.6:

>_When using unresolved resonance formalisms with energy dependent parameters (e.g. the fission width, etc.), these data need to be defined over the entire unresolved resonance region. In rare cases, such as ENDF/BVII.0 Pu239, this is not the case, leading to NaN cross section values. This is an evaluation error._

While running UNRESR is generally preferable and part of our canonical methods for ALARAJOYWrapper, I think an evaluation error of this sort is not resolvable by us. Even without UNRESR, however, GASPR and GROUPR can still be run and the best possible data can be extracted from any given file with this issue.

A second issue in the TENDL-2014 data is that there are a number of files that are misnamed, such as the files for <sup>285</sup>Nh and <sup>286</sup>Nh, which for some reason have the symbol A3 instead. This update will catch this type of issue, identify the proper nuclide identifiers from the file itself and then rename it to match the correct nuclide data.

Finally, for a number of TENDL-2014 nuclides the RECONR error tolerance that was otherwise a fixed value was leading to NJOY stalling out and unable to resolve the reconstructions. I've included a looping mechanism to test out various timeout lengths before increasing this tolerance value to try to isolate the need to raise it only to cases where NJOY is truly unable to perform the calculation, rather than just doing so slowly.