### PR TITLE
Extracting KZAs directly from ENDF files, independently from filename

### DIFF
--- a/tools/ALARAJOYWrapper/preprocess_fendl3.py
+++ b/tools/ALARAJOYWrapper/preprocess_fendl3.py
@@ -8,8 +8,6 @@ import warnings
 from pathlib import Path
 from collections import defaultdict
 
-ISOMERIC_STATES = 'mnopqrstuvwxyz'
-
 def args():
     parser = argparse.ArgumentParser()
     parser.add_argument(
@@ -48,69 +46,6 @@ def args():
     )
     return parser.parse_args()
 
-def calculate_pKZA(element, A):
-    """
-    Construct the target (parent) nuclide's KZA value. KZA values are defined
-        as ZZAAAM, where ZZ is the nuclide's atomic number, AAA is the mass
-        number, and M is the isomeric state (0 if ground state).
-
-    Arguments:
-        element (str): Chemical symbol of the target nuclide.
-        A (int or str): Mass number of the nuclide, potentially including an
-            isomeric tag, such as "m" for the first excited state, "n" for the
-            second, etc. (Note: TENDL data should only include up to a maximum
-            of the second excited state).
-
-    Returns:
-        pKZA (int): KZA value of the target nuclide.
-    """
-
-    Z = njt.elements[element]
-    A = str(A).lower()
-
-    # Metastable states classified by TENDL as m = 1, n = 2, etc.
-    # (Generally expecting only m, occasionally n, but physically,
-    # values could go higher, so isomeric_states goes up to z = 14)
-    M = 0
-    isomer_tag = next(
-        (tag for tag in ISOMERIC_STATES if tag in A), None
-    )
-    if isomer_tag:
-        M = ISOMERIC_STATES.find(isomer_tag) + 1
-    
-    if M > 2:
-        warnings.warn(
-            f'Isomeric state greater than 2. Unexpected case for TENDL2017.',
-            UserWarning
-        )
-
-    A = int(A.split(isomer_tag)[0])
-    return (Z * 1000 + A) * 10 + M
-
-def interpret_KZA(kza):
-    """
-    Infer the chemical symbol and mass number from a KZA (ZZAAAM) number.
-
-    Arguments:
-        kza (int): Unique ZZAAAM for a given nuclide.
-
-    Returns:
-        element (str): Chemical symbol of the target nuclide.
-        A (str or int): Mass number for selected isotope.
-            If the target is a metastable isomer, "m" or "n" is written after 
-            the mass number, corresponding to the first or second metastable
-            states.
-    """
-
-    kza = str(kza)
-    A = kza[-4:-1]
-    Z = kza[:kza.find(A)].zfill(2)
-    element = list(njt.elements.keys())[int(Z) - 1]
-    M = int(kza[-1])
-    if M > 0:
-        A += ISOMERIC_STATES[M - 1]
-
-    return element, A
 
 def process_pendf(
     njoy_prep_input, material_id, MTs, pKZA, mt_dict, temperature, tendl_path
@@ -148,7 +83,7 @@ def process_pendf(
             is successful.
     """
 
-    element, A = interpret_KZA(pKZA)
+    element, A = tp.interpret_KZA(pKZA)
     njoy_error = ''
     njoy_input = njt.fill_input_template(
         njoy_prep_input, material_id, MTs, element, A, mt_dict, temperature
@@ -207,7 +142,7 @@ def process_gendf(
             reaction pathways for the given parent and its MTs.
     """
 
-    element, A = interpret_KZA(pKZA)
+    element, A = tp.interpret_KZA(pKZA)
     groupr_input = njt.fill_input_template(
         njoy_groupr_input, material_id, MTs, element,
         A, mt_dict, temperature, pKZA, isomer_dict
@@ -232,19 +167,19 @@ def process_gendf(
                 gendf_MTs, mt_dict, xs_line_dict, pKZA, 
                 all_rxns, eaf_nucs, isomer_dict, gendf_path
             )
-            print(f'Finished processing {element}{A}')
+            print(f'Finished processing {element}-{A}')
 
         else:
             warnings.warn(
                 f'''The requested file (MF3) is not present in the
-                ENDF file tree for {element}{A}'''
+                ENDF file tree for {element}-{A}'''
             )
             with open('mf_fail.log', 'a') as fail:
-                fail.write(f'{element}{A} \n')
+                fail.write(f'{element}-{A} \n')
 
     else:
         warnings.warn(
-            f'''Failed to convert {element}{A}.
+            f'''Failed to convert {element}-{A}.
             NJOY error message: {njoy_error}'''
         )
 
@@ -400,10 +335,7 @@ def main():
     all_rxns = defaultdict(lambda: defaultdict(dict))
 
     for file_properties in tp.search_for_files(search_dir):
-        element = file_properties['Element']
-        A = file_properties['Mass Number']
-        pKZA = calculate_pKZA(element, A)
-        endf_path = file_properties['TENDL File Path']
+        element, A, pKZA, endf_path = tuple(file_properties.values())
         TAPE20.write_bytes(endf_path.read_bytes())
 
         material_id, MTs = tp.extract_endf_specs(TAPE20)
@@ -429,7 +361,7 @@ def main():
 
         else:
             warnings.warn(
-                f'''PENDF preparation failed for {element}{A}.
+                f'''PENDF preparation failed for {element}-{A}.
                 NJOY error message: {njoy_prep_error}'''
             )
 

--- a/tools/ALARAJOYWrapper/tendl_processing.py
+++ b/tools/ALARAJOYWrapper/tendl_processing.py
@@ -150,7 +150,7 @@ def search_for_files(dir = Path.cwd()):
                     'Element'         :            element,
                     'Mass Number'     :                  A,
                     'pKZA'            :               pKZA,
-                    'TENDL File Path' : formatted_filename
+                    'TENDL File Path' :       new_filename
                 })
 
     return file_info

--- a/tools/ALARAJOYWrapper/tendl_processing.py
+++ b/tools/ALARAJOYWrapper/tendl_processing.py
@@ -138,12 +138,12 @@ def search_for_files(dir = Path.cwd()):
                     break
 
             else:
-                formatted_filename = dir / f'{element}{A}.tendl'
-                if formatted_filename != file:
-                    file.rename(formatted_filename)
+                new_filename = dir / f'{element}{A.split(str(0))[-1]}.tendl'
+                if new_filename != file:
+                    file.rename(new_filename)
                     warnings.warn(
                         f'Improperly named TENDL file {file} renamed to ' \
-                        f'{formatted_filename} to match nuclide ID.'
+                        f'{new_filename} to match nuclide ID.'
                     )
 
                 file_info.append({

--- a/tools/ALARAJOYWrapper/tendl_processing.py
+++ b/tools/ALARAJOYWrapper/tendl_processing.py
@@ -2,6 +2,7 @@
 import ENDFtk
 from pathlib import Path
 from reaction_data import GAS_DF
+from njoy_tools import elements
 from collections import defaultdict
 import warnings
 import numpy as np
@@ -22,75 +23,7 @@ REVERSE_EXCITATION_DICT = {
     for key, arr in EXCITATION_DICT.items()
     for val in arr
 }
-
-def get_isotope(stem):
-    """
-    Extract the element name and mass number from a given filename.
-    Arguments:
-        stem (str): Stem of a an ENDF (TENDL) and/or PENDF file, formatted
-            as f'{element}{mass_number}.ext'
-
-    Returns:
-        element (str): Chemical symbol of the isotope whose data is contained
-            in the file.
-        A (str): Mass number of the isotope, potentially including the letter
-            "m" at the end if the isotope is in a metastable state.
-    """
-
-    for i, char in enumerate(stem):
-        if char.isdigit():
-            break
-
-    element = stem[:i]
-    A = stem[i:]       
-
-    return element, A
-
-def search_for_files(dir = Path.cwd()):
-    """
-    Search through a directory for all pairs of ENDF (TENDL) and PENDF files
-        that have matching stems. If so, save the paths and the isotopic
-        information to a dictionary.
-    
-    Arguments:
-        directory (pathlib._local.PosixPath, optional): Path to the directory
-            in which to search for ENDF and PENDF files.
-            Defaults to the present working directory (".").
-
-    Returns:
-        file_info (list of dicts): List of dictionaries containing the
-            chemical symbol, mass number, and paths to the TENDL (ENDF) files
-            for a given isotope. These dictionaries are formatted as such:
-                {
-                    'Element'     : Isotope's chemical symbol,
-                    'Mass Number' : Isotope's mass number,
-                    'File Paths'  : endf_path, pendf_path
-                }
-    """
-
-    file_info = []
-    for suffix in ['tendl', 'endf']:
-        # Iterate alphabetically for debugging to spot where process fails
-        for file in sorted(dir.glob(f'*.{suffix}')):
-            element, A = get_isotope(file.stem)
-            for existing_file in file_info:
-                if (
-                    existing_file['Element'] == element
-                    and existing_file['Mass Number'] == A
-                ):
-                    warnings.warn(
-                        f'Multiple files present in {dir} for {element}-{A}'
-                    )
-                    break
-
-            else:
-                file_info.append({
-                    'Element'         :         element,
-                    'Mass Number'     :               A,
-                    'TENDL File Path' :            file
-                })
-
-    return file_info
+ISOMERIC_STATES = 'mnopqrstuvwxyz'
 
 def create_endf_file_obj(path, MF):
     """
@@ -114,6 +47,113 @@ def create_endf_file_obj(path, MF):
         file = material.file(MF)
 
     return file, matb
+
+def calculate_KZA_from_ENDF(filepath, MF=1, MT=451):
+    """
+    Use the ZA and LISO flags from a an MF,MT section of a single nuclide ENDF
+        formatted nuclear data file to construct a unique idenfifier for the
+        nuclide in the KZA (ZZZAAAM) format.
+
+    Arguments:
+        filepath (pathlib._local.PosixPath): Path for an ENDF-formatted file.
+        MF (int, optional): Option to specify the ENDF data block ("file")
+            from which to extract identifying data. Unless specified, will
+            direct to MF = 1 ("General Information").
+            (Defaults to 1).
+        MT (int, optional): Option to specify the file section within an ENDF
+            data block (MF) from which to extract identifying data. Unless
+            specificed, will direct to MF = 451 ("Descriptive Data and
+            Directory").
+            (Defaults to 457)
+
+    Returns:
+        KZA (int): Unique ZZZAAM for a given nuclide.
+    """
+
+    endf_file_obj, _ = create_endf_file_obj(filepath, MF)
+    nuc_data = endf_file_obj.section(MT).parse()
+    return nuc_data.ZA * 10 + nuc_data.LISO
+
+def interpret_KZA(kza):
+    """
+    Infer the chemical symbol and mass number from a KZA (ZZAAAM) number.
+
+    Arguments:
+        kza (int): Unique ZZZAAAM for a given nuclide.
+
+    Returns:
+        element (str): Chemical symbol of the target nuclide.
+        A (str or int): Mass number for selected isotope.
+            If the target is a metastable isomer, "m" or "n" is written after 
+            the mass number, corresponding to the first or second metastable
+            states.
+    """
+
+    kza = str(kza)
+    A = kza[-4:-1]
+    Z = kza[:kza.find(A)].zfill(2)
+    element = list(elements.keys())[int(Z) - 1]
+    M = int(kza[-1])
+    if M > 0:
+        A += ISOMERIC_STATES[M - 1]
+
+    return element, A
+
+def search_for_files(dir = Path.cwd()):
+    """
+    Search through a directory for all pairs of ENDF (TENDL) and PENDF files
+        that have matching stems. If so, save the paths and the isotopic
+        information to a dictionary.
+    
+    Arguments:
+        directory (pathlib._local.PosixPath, optional): Path to the directory
+            in which to search for ENDF and PENDF files.
+            Defaults to the present working directory (".").
+
+    Returns:
+        file_info (list of dicts): List of dictionaries containing the
+            chemical symbol, mass number, and paths to the TENDL (ENDF) files
+            for a given nuclide. These dictionaries are formatted as such:
+                {
+                    'Element'     : Nuclide's chemical symbol,
+                    'Mass Number' : Nuclide's mass number,
+                    'pKZA'        : Nuclide's KZA value,
+                    'File Paths'  : endf_path, pendf_path
+                }
+    """
+
+    file_info = []
+    for suffix in ['tendl', 'endf']:
+        # Iterate alphabetically for debugging to spot where process fails
+        for file in sorted(dir.glob(f'*.{suffix}')):
+            pKZA = calculate_KZA_from_ENDF(file, 1, 451)
+            element, A = interpret_KZA(pKZA)
+
+            for existing_file in file_info:
+                if existing_file['pKZA'] == pKZA:
+                    warnings.warn(
+                        f'Multiple files present in {dir} for ' \
+                        f'{element}-{A}.'
+                    )
+                    break
+
+            else:
+                formatted_filename = dir / f'{element}{A}.tendl'
+                if formatted_filename != file:
+                    file.rename(formatted_filename)
+                    warnings.warn(
+                        f'Improperly named TENDL file {file} renamed to ' \
+                        f'{formatted_filename} to match nuclide ID.'
+                    )
+
+                file_info.append({
+                    'Element'         :            element,
+                    'Mass Number'     :                  A,
+                    'pKZA'            :               pKZA,
+                    'TENDL File Path' : formatted_filename
+                })
+
+    return file_info
 
 def extract_endf_specs(path):
     """

--- a/tools/ALARAJOYWrapper/tendl_processing.py
+++ b/tools/ALARAJOYWrapper/tendl_processing.py
@@ -138,7 +138,7 @@ def search_for_files(dir = Path.cwd()):
                     break
 
             else:
-                new_filename = dir / f'{element}{A.split(str(0))[-1]}.tendl'
+                new_filename = dir / f'{element}{A}.tendl'
                 if new_filename != file:
                     file.rename(new_filename)
                     warnings.warn(

--- a/tools/ALARAJOYWrapper/tendl_processing.py
+++ b/tools/ALARAJOYWrapper/tendl_processing.py
@@ -83,17 +83,17 @@ def interpret_KZA(kza):
 
     Returns:
         element (str): Chemical symbol of the target nuclide.
-        A (str or int): Mass number for selected isotope.
+        A (str): Mass number for selected isotope.
             If the target is a metastable isomer, "m" or "n" is written after 
             the mass number, corresponding to the first or second metastable
             states.
     """
 
-    kza = str(kza)
-    A = kza[-4:-1]
-    Z = kza[:kza.find(A)].zfill(2)
-    element = list(elements.keys())[int(Z) - 1]
-    M = int(kza[-1])
+    M = kza % 10
+    za = kza // 10
+    A = str(za % 1000)
+    Z = za // 1000
+    element = list(elements.keys())[Z - 1]
     if M > 0:
         A += ISOMERIC_STATES[M - 1]
 


### PR DESCRIPTION
This PR follows conversations from #271 and #279 to identify nuclides directly from the data contained within their ENDF files, rather than relying on them being named correctly. As it stood, relying on files to be named correctly was a rather fragile system, so this PR should provide a more stable basis by which to establish nuclide identity in the form of KZA, and then subsequently extract all other identifying characteristics (chemical symbol, mass number, isomeric state) from the KZA itself. 
