### PR TITLE
Enabling ALARAJOY to Convert to Group Structures beyond Vitamin-J

### DIFF
--- a/tools/ALARAJOYWrapper/README.md
+++ b/tools/ALARAJOYWrapper/README.md
@@ -22,6 +22,7 @@ This preprocessor uses [NJOY 2016](https://github.com/njoy/NJOY2016) Nuclear Dat
 - Domain-specific packages
   * [ENDFtk](https://github.com/njoy/ENDFtk)
   * [NJOY 2016](https://github.com/njoy/NJOY2016) (built with `develop` branch)
+  * [OpenMC](https://docs.openmc.org/en/stable/quickinstall.html) (only needed if specifying a multigroup energy structure by name from the dictionary `openmc.mgxs.GROUP_STRUCTURES`)
 
 
 ## Usage
@@ -33,7 +34,7 @@ To run this preprocessor, the user must first have acquired TENDL files for each
 
 Running ALARAJOYWrapper can be done with one Python command:
 ```
-python preprocess_fendl3.py -f /path/to/fendl3_data_dir/ -d /path/to/eaf_decay_library/ -a -t -r
+python preprocess_fendl3.py -f /path/to/fendl3_data_dir/ -d /path/to/eaf_decay_library/ -a -t -r -g
 ```
 To read in detail about each of these arguments, call this command:
 ```

--- a/tools/ALARAJOYWrapper/njoy_tools.py
+++ b/tools/ALARAJOYWrapper/njoy_tools.py
@@ -164,11 +164,12 @@ def set_group_structure(group_struct_arg):
         structure is desired, however, there are three ways in which this
         group structure can be set:
 
-        1) Provide the GROUPR `ign` key corresponding to the desired group
-        structure. NJOY has 33 built-in group structures from which GROUPR can
-        access their data, including for Vitamin-J. These can be found in
-        Section 8.18 ("Running GROUPR") of the NJOY User Manual
-        (https://github.com/njoy/NJOY2016-manual/raw/master/njoy16.pdf).
+        1) Provide the GROUPR `ign` key or group name corresponding to the
+        desired group structure. NJOY has 33 built-in group structures from
+        which GROUPR can access their data, including for Vitamin-J. These can
+        be found in Section 8.18 ("Running GROUPR") of the NJOY User Manual
+        (https://github.com/njoy/NJOY2016-manual/raw/master/njoy16.pdf) or in
+        the dictionary njoy_tools.NJOY_GROUPS.
 
         2) Provide a support file containing the explicit energy bounds of a
         multi-group energy structure. NJOY is not limited to its pre-set
@@ -195,14 +196,13 @@ def set_group_structure(group_struct_arg):
         can be found at https://docs.openmc.org/en/stable/pythonapi/mgxs.html.
     
     Arguments:
-        group_struct_arg (None or list of str): Group structure argument
-            following procedures described above or None, if default
-            Vitamin-J 175 group structure settings to be applied.
+        group_struct_arg (list of str): Group structure argument following the 
+            procedures described above.
 
     Returns:
-        ign (str or int): GROUPR neutron group structure parameter. ign = 1
-            for arbitrary group structures not contained in NJOY's built-in
-            list of options.
+        ign (int): GROUPR neutron group structure parameter. ign = 1 for
+            arbitrary group structures not contained in NJOY's built-in list
+            of options.
         ngn (str): Number of groups. Will be an empty string unless ign == 1.
         egn (str): Space-joined string of all energy group bounds in
             ascending order. Will be an empty string unless ign == 1.
@@ -211,47 +211,48 @@ def set_group_structure(group_struct_arg):
 
     ngn = ''
     egn = ''
+    group_struct = group_struct_arg[0]
 
-    # Default to Vitamin-J group structure if none is provided from args
-    if group_struct_arg is None:
-        ign = 17
-        group_name = 'VITAMIN-J-175'
+    # Check if provided group structure is among the list of built-in NJOY
+    # group structures by key (ign values 2-34)
+    if group_struct in np.array(list(NJOY_GROUPS)).astype(str):
+        ign = int(group_struct)
+        group_name = NJOY_GROUPS[ign]
 
+    # Check if provided group structure is among the list of built-in NJOY
+    # group structures by name (values of NJOY_GROUPS dict)
+    elif group_struct.upper() in NJOY_GROUPS.values():
+        group_name = group_struct.upper()
+        ign = list(NJOY_GROUPS.keys())[
+            list(NJOY_GROUPS.values()).index(group_name)
+        ]
+
+    # NJOY "arbitrary group structure" option
     else:
-        group_struct = group_struct_arg[0]
+        ign = 1
+        group_bounds = []
+        # If support file containing group bounds is provided, load them
+        # into an array
+        if Path(group_struct).is_file():
+            group_bounds = np.loadtxt(group_struct)
+            group_name = f'CUSTOM-{len(group_bounds)}'
 
-        # Check if provided group structure is among the list of built-in NJOY
-        # group structures (ign values 2-34)
-        if group_struct in np.array(list(NJOY_GROUPS)).astype(str):
-            ign = group_struct
-            group_name = NJOY_GROUPS[int(group_struct)]
-
-        # NJOY "arbitrary group structure" option
+        # If group structure name is provided, extract values from OpenMC
         else:
-            ign = 1
-            group_bounds = []
-            # If support file containing group bounds is provided, load them
-            # into an array
-            if Path(group_struct).is_file():
-                group_bounds = np.loadtxt(group_struct)
-                group_name = f'CUSTOM-{len(group_bounds)}'
+            from openmc.mgxs import GROUP_STRUCTURES
+            group_name = group_struct.upper()
+            group_bounds = GROUP_STRUCTURES.get(group_name, [])
 
-            # If group structure name is provided, extract values from OpenMC
-            else:
-                from openmc.mgxs import GROUP_STRUCTURES
-                group_name = group_struct.upper()
-                group_bounds = GROUP_STRUCTURES.get(group_name, [])
-
-            if len(group_bounds) == 0:
-                raise ValueError(
-                    'Invalid group structure provided. Must either be an '  \
-                    'ign value known by NJOY, a group structure name in '   \
-                    '`openmc.mgxs.GROUP_STRUCTURES`, or a file containing ' \
-                    'explicit energy group bounds.'
-                )
-            
-            ngn = str(len(group_bounds) - 1)
-            egn = ' '.join(np.array(sorted(group_bounds)).astype(str))
+        if len(group_bounds) == 0:
+            raise ValueError(
+                'Invalid group structure provided. Must either be an '  \
+                'ign value known by NJOY, a group structure name in '   \
+                '`openmc.mgxs.GROUP_STRUCTURES`, or a file containing ' \
+                'explicit energy group bounds.'
+            )
+        
+        ngn = str(len(group_bounds) - 1)
+        egn = ' '.join(np.array(sorted(group_bounds)).astype(str))
 
     return ign, ngn, egn, group_name
 

--- a/tools/ALARAJOYWrapper/njoy_tools.py
+++ b/tools/ALARAJOYWrapper/njoy_tools.py
@@ -235,7 +235,9 @@ def set_group_structure(group_struct_arg):
         # into an array
         if Path(group_struct).is_file():
             group_bounds = np.loadtxt(group_struct)
-            group_name = f'CUSTOM-{len(group_bounds)}'
+            group_name = 'user-provided ' + (
+                f'{Path(group_struct).stem.upper()}-{len(group_bounds) - 1}'
+            )
 
         # If group structure name is provided, extract values from OpenMC
         else:

--- a/tools/ALARAJOYWrapper/njoy_tools.py
+++ b/tools/ALARAJOYWrapper/njoy_tools.py
@@ -3,6 +3,7 @@ from string import Template
 import subprocess
 from pathlib import Path
 import re
+import numpy as np
 
 def set_directory():
     '''
@@ -75,10 +76,12 @@ groupr_input = Template(Template(
 """
 groupr/
  $NENDF $NPEND $NGOUT1 $NGOUT2/
- $mat_id $IGN $IGG $IWT $LORD $NTEMP $NSIGZ $IPRINT_groupr/
+ $mat_id $ign $IGG $IWT $LORD $NTEMP $NSIGZ $IPRINT_groupr/
  $title/
  $groupr_temp
  $SIGZ_groupr/
+ $ngn
+ $egn
  $reactions
  $MATD/
  0/
@@ -89,7 +92,6 @@ stop
     NPEND = 25,         # unit for final PENDF tape (equivalent to NOUT_gaspr)
     NGOUT1 = 0,                         # unit for input gout tape (default=0)
     NGOUT2 = 31,                       # unit for output gout tape (default=0)
-    IGN = 17,    # neutron group structure option (corresponding to Vitamin J)
     IGG = 0,                                    # gamma group structure option
     IWT = 11,            # weight function option (corresponding to Vitamin E)
     LORD = 0,                                                 # Legendre order
@@ -115,6 +117,102 @@ elements = [
     'Rg', 'Cn', 'Nh', 'Fl', 'Mc', 'Lv', 'Ts', 'Og'
 ]
 elements = dict(zip(elements, range(1, len(elements)+1)))
+
+def set_group_structure(group_struct_arg):
+    """
+    Interpret the group_structure argument (`-g`) to define the requisite NJOY
+        parameters to convert TENDL data to the given multi-group energy
+        structure. By default, the Vitamin-J 175 group structure is used for
+        ALARAJOY preprocessing and this function will return the appropriate
+        values for NJOY to run GROUPR with these settings. If another group
+        structure is desired, however, there are three ways in which this
+        group structure can be set:
+
+        1) Provide the GROUPR `ign` key corresponding to the desired group
+        structure. NJOY has 33 built-in group structures from which GROUPR can
+        access their data, including for Vitamin-J. These can be found in
+        Section 8.18 ("Running GROUPR") of the NJOY User Manual
+        (https://github.com/njoy/NJOY2016-manual/raw/master/njoy16.pdf).
+
+        2) Provide a support file containing the explicit energy bounds of a
+        multi-group energy structure. NJOY is not limited to its pre-set
+        structures, and is capable of converting cross-sections to an
+        arbitrary group structure, so long as the energy bounds and number of
+        groups are provided. To use this option format the support file as:
+
+            BOUND_1
+            BOUND_2
+            ...
+            BOUND_N
+        
+        The order in the support file can be arbitrary because after being
+        read in, the values will be sorted to ensure compliance to NJOY's
+        expectation of ascending energy bounds for an arbitrary group
+        structure.
+
+        3) Provide a group-structure name corresponding to a key in the
+        `openmc.mgxs.GROUP_STRUCTURES` dictionary. The open-source Monte Carlo
+        neutron transport code OpenMC contains a number of multi-group energy
+        structures that may be applicable for activation studies but are not
+        included in the list of NJOY options mentioned in `(1)`, such as the
+        'CCFE-709' group structure used by FISPACT-II. These group structures
+        can be found at https://docs.openmc.org/en/stable/pythonapi/mgxs.html.
+    
+    Arguments:
+        group_struct_arg (None or list of str): Group structure argument
+            following procedures described above or None, if default
+            Vitamin-J 175 group structure settings to be applied.
+
+    Returns:
+        ign (str): GROUPR neutron group structure parameter. ign = 1 for
+            arbitrary group structures not contained in NJOY's built-in list
+            of options.
+        ngn (str): Number of groups. Will be an empty string unless ign == 1.
+        egn (str): Space-joined string of all energy group bounds in
+            ascending order. Will be an empty string unless ign == 1.
+    """
+
+    ngn = ''
+    egn = ''
+
+    # Default to Vitamin-J group structure if none is provided from args
+    if group_struct_arg is None:
+        ign = 17 # NJOY flag for Vitamin-J
+
+    else:
+        group_struct = group_struct_arg[0]
+
+        # Check if provided group structure is among the list of built-in NJOY
+        # group structures (ign values 2-34)
+        if group_struct in range(2,35):
+            ign = group_struct
+
+        # NJOY "arbitrary group structure" option
+        else:
+            ign = 1
+            group_bounds = []
+            # If support file containing group bounds is provided, load them
+            # into an array
+            if Path(group_struct).is_file():
+                group_bounds = np.loadtxt(group_struct)
+
+            # If group structure name is provided, extract values from OpenMC
+            else:
+                from openmc.mgxs import GROUP_STRUCTURES
+                group_bounds = GROUP_STRUCTURES.get(group_struct.upper(), [])
+
+            if len(group_bounds) == 0:
+                raise ValueError(
+                    'Invalid group structure provided. Must either be an '  \
+                    'ign value known by NJOY, a group structure name in '   \
+                    '`openmc.mgxs.GROUP_STRUCTURES`, or a file containing ' \
+                    'explicit energy group bounds.'
+                )
+            
+            ngn = str(len(group_bounds) - 1)
+            egn = ' '.join(np.array(sorted(group_bounds)).astype(str))
+
+    return ign, ngn, egn
 
 def card9_special_isomer_reactions(pKZA, MT, mt_data, isomer_data, mtname):
     """
@@ -168,7 +266,7 @@ def card9_special_isomer_reactions(pKZA, MT, mt_data, isomer_data, mtname):
 
 def fill_input_template(
     inp, material_id, MTs, element, A, mt_dict, temperature,
-    pKZA=None, isomer_dict={}
+    pKZA=None, isomer_dict={}, ign=17, ngn='', egn=''
 ):
     """
     Substitute in the material-specific values for a given ENDF/PENDF file
@@ -201,12 +299,38 @@ def fill_input_template(
             states of the residual daughter. Only needed when filling the
             GROUPR-specific template.
             (Defaults to {})
+        ign (str or int, optional): GROUPR neutron group structure parameter.
+            ign = 1 for arbitrary group structures not contained in NJOY's
+            built-in list of options. Default value corresponds to ign key for
+            the Vitamin-J 175 energy group structure.
+            (Defaults to 17)
+        ngn (str, optional): Number of groups. Will be an empty string unless
+            ign == 1.
+            (Defaults to '')
+        egn (str): Space-joined string of all energy group bounds in ascending
+            order. Will be an empty string unless ign == 1.
+            (Defaults to '')
     
     Returns:
         template (str): Modified template with the material-
             specific information substituted in for the $identifiers,
             converted to a string.
     """
+
+    # Card 6 special handling for explicitly defined energy groups
+    if ign == 1:
+        if not ngn or not egn:
+            raise ValueError(
+                'In order to convert to arbitrary group structure ' \
+                '(ign == 1), GROUPR requires the number of groups (ngn) and' \
+                ' the group boundaries (egn).\nWhen using njoy_tools within ' \
+                'preprocess_fendl3.py, either include a group structure ' \
+                'defined in openmc.mgxs.GROUP_STRUCTURES or provide a file ' \
+                'as a second value for the -g argument that explicitly ' \
+                'lists the group boundaries.'
+            )
+        ngn += ' /'
+        egn += ' /'
 
     Z = str(elements[element]).zfill(2)
     title = f'"{Z}-{element}-{A} for TENDL 2017"'
@@ -231,7 +355,10 @@ def fill_input_template(
         self_shielding_temp=temperature,
         final_broadr_temp=temperature,
         groupr_temp=temperature,
-        title=title,                                            
+        title=title,
+        ign=ign,
+        ngn=ngn,
+        egn=egn,                     
         reactions=card9,                                        
     )
 

--- a/tools/ALARAJOYWrapper/njoy_tools.py
+++ b/tools/ALARAJOYWrapper/njoy_tools.py
@@ -118,6 +118,42 @@ elements = [
 ]
 elements = dict(zip(elements, range(1, len(elements)+1)))
 
+NJOY_GROUPS = {
+    2  :          'CSWEG-239',
+    3  :            'LANL-30',
+    4  :             'ANL-27',
+    5  :             'RRD-50',
+    6  :           'GAM-I-68',
+    7  :         'GAM-II-100',
+    8  :   'LASER-THERMOS-35',
+    9  :        'EPRI-CPM-69',
+    10 :           'LANL-187',
+    11 :            'LANL-70',
+    12 :        'SAND-II-620',
+    13 :            'LANL-80',
+    14 :         'EURLIB-100',
+    15 :       'SAND-IIA-640',
+    16 :      'VITAMIN-E-174',
+    17 :      'VITAMIN-J-175',
+    18 :      'XMAS-NEA-LANL',
+    19 :            'ECCO-33',
+    20 :          'ECCO-1968',
+    21 :        'TRIPOLI-315',
+    22 :      'XMAS-LWPC-172',
+    23 : 'VITAMIN-J-LWPC-175',
+    24 :       'SHEM-CEA-281',
+    25 :       'SHEM-EPM-291',
+    26 :   'SHEM-CEA/EPM-361',
+    27 :       'SHEM-EPM-315',
+    28 :      'RAHAB-AECL-89',
+    29 :           'CCFE-660',
+    30 :         'UKAEA-1025',
+    31 :         'UKAEA-1067',
+    32 :         'UKAEA-1102',
+    33 :          'UKAEA-142',
+    34 :           'LANL-618'
+}
+
 def set_group_structure(group_struct_arg):
     """
     Interpret the group_structure argument (`-g`) to define the requisite NJOY
@@ -170,6 +206,7 @@ def set_group_structure(group_struct_arg):
         ngn (str): Number of groups. Will be an empty string unless ign == 1.
         egn (str): Space-joined string of all energy group bounds in
             ascending order. Will be an empty string unless ign == 1.
+        group_name (str): Name of the provided group structure.
     """
 
     ngn = ''
@@ -177,15 +214,17 @@ def set_group_structure(group_struct_arg):
 
     # Default to Vitamin-J group structure if none is provided from args
     if group_struct_arg is None:
-        ign = 17 # NJOY flag for Vitamin-J
+        ign = 17
+        group_name = 'VITAMIN-J-175'
 
     else:
         group_struct = group_struct_arg[0]
 
         # Check if provided group structure is among the list of built-in NJOY
         # group structures (ign values 2-34)
-        if group_struct in np.arange(2,35).astype(str):
+        if group_struct in np.array(list(NJOY_GROUPS)).astype(str):
             ign = group_struct
+            group_name = NJOY_GROUPS[int(group_struct)]
 
         # NJOY "arbitrary group structure" option
         else:
@@ -195,11 +234,13 @@ def set_group_structure(group_struct_arg):
             # into an array
             if Path(group_struct).is_file():
                 group_bounds = np.loadtxt(group_struct)
+                group_name = f'CUSTOM-{len(group_bounds)}'
 
             # If group structure name is provided, extract values from OpenMC
             else:
                 from openmc.mgxs import GROUP_STRUCTURES
-                group_bounds = GROUP_STRUCTURES.get(group_struct.upper(), [])
+                group_name = group_struct.upper()
+                group_bounds = GROUP_STRUCTURES.get(group_name, [])
 
             if len(group_bounds) == 0:
                 raise ValueError(
@@ -212,7 +253,7 @@ def set_group_structure(group_struct_arg):
             ngn = str(len(group_bounds) - 1)
             egn = ' '.join(np.array(sorted(group_bounds)).astype(str))
 
-    return ign, ngn, egn
+    return ign, ngn, egn, group_name
 
 def card9_special_isomer_reactions(pKZA, MT, mt_data, isomer_data, mtname):
     """

--- a/tools/ALARAJOYWrapper/njoy_tools.py
+++ b/tools/ALARAJOYWrapper/njoy_tools.py
@@ -164,9 +164,9 @@ def set_group_structure(group_struct_arg):
             Vitamin-J 175 group structure settings to be applied.
 
     Returns:
-        ign (str): GROUPR neutron group structure parameter. ign = 1 for
-            arbitrary group structures not contained in NJOY's built-in list
-            of options.
+        ign (str or int): GROUPR neutron group structure parameter. ign = 1
+            for arbitrary group structures not contained in NJOY's built-in
+            list of options.
         ngn (str): Number of groups. Will be an empty string unless ign == 1.
         egn (str): Space-joined string of all energy group bounds in
             ascending order. Will be an empty string unless ign == 1.

--- a/tools/ALARAJOYWrapper/njoy_tools.py
+++ b/tools/ALARAJOYWrapper/njoy_tools.py
@@ -231,8 +231,8 @@ def set_group_structure(group_struct_arg):
     else:
         ign = 1
         group_bounds = []
-        # If support file containing group bounds is provided, load them
-        # into an array
+        # If support file containing group bounds is provided, load them into
+        # an array
         if Path(group_struct).is_file():
             group_bounds = np.loadtxt(group_struct)
             group_name = 'user-provided ' + (
@@ -247,8 +247,8 @@ def set_group_structure(group_struct_arg):
 
         if len(group_bounds) == 0:
             raise ValueError(
-                'Invalid group structure provided. Must either be an '  \
-                'ign value known by NJOY, a group structure name in '   \
+                'Invalid group structure provided. Must either be an ign '  \
+                'value known by NJOY, a group structure name in '   \
                 '`openmc.mgxs.GROUP_STRUCTURES`, or a file containing ' \
                 'explicit energy group bounds.'
             )

--- a/tools/ALARAJOYWrapper/njoy_tools.py
+++ b/tools/ALARAJOYWrapper/njoy_tools.py
@@ -184,7 +184,7 @@ def set_group_structure(group_struct_arg):
 
         # Check if provided group structure is among the list of built-in NJOY
         # group structures (ign values 2-34)
-        if group_struct in range(2,35):
+        if group_struct in np.arange(2,35).astype(str):
             ign = group_struct
 
         # NJOY "arbitrary group structure" option

--- a/tools/ALARAJOYWrapper/preprocess_fendl3.py
+++ b/tools/ALARAJOYWrapper/preprocess_fendl3.py
@@ -53,10 +53,10 @@ def make_argparser():
         ''')
     )
     parser.add_argument(
-        '--group_structure', '-g', required=False, nargs=1,
+        '--group_structure', '-g', required=False, nargs=1, default=['17'],
         help=('''
             Specification for group structure in which to convert TENDL cross-
-                sections. See tendl_processing.set_group_structure() for
+                sections. See njoy_tools.set_group_structure() for
                 specific details for acceptable forms in which to supply this
                 argument.
         ''')

--- a/tools/ALARAJOYWrapper/preprocess_fendl3.py
+++ b/tools/ALARAJOYWrapper/preprocess_fendl3.py
@@ -407,7 +407,7 @@ def main():
         Path(args.fendlFileDir[0]) if args.fendlFileDir else dir
     )
     temperature = args.temperature[0]
-    ign, ngn, egn = njt.set_group_structure(args.group_structure)
+    ign, ngn, egn, group_name = njt.set_group_structure(args.group_structure)
 
     mt_dict = rxd.process_mt_data(rxd.load_mt_table(dir / 'mt_table.csv'))
     eaf_nucs = rxd.find_eaf_ref_data(Path(args.decay_lib[0]))
@@ -455,6 +455,10 @@ def main():
 
     dsv_path = dir / 'cumulative_gendf_data.dsv'
     write_dsv(dsv_path, gas_filtered, nGroups)
+    print(
+        f'Neutron activation cross-sections converted to {nGroups} groups ' \
+        f'according to the {group_name} group structure.'
+    )
     print(f'Reaction data saved to: {dsv_path}')
 
 if __name__ == '__main__':

--- a/tools/ALARAJOYWrapper/preprocess_fendl3.py
+++ b/tools/ALARAJOYWrapper/preprocess_fendl3.py
@@ -56,9 +56,8 @@ def make_argparser():
         '--group_structure', '-g', required=False, nargs=1, default=['17'],
         help=('''
             Specification for group structure in which to convert TENDL cross-
-                sections. See njoy_tools.set_group_structure() for
-                specific details for acceptable forms in which to supply this
-                argument.
+                sections. See njoy_tools.set_group_structure() for specific
+                details for acceptable forms in which to supply this argument.
         ''')
     )
     return parser

--- a/tools/ALARAJOYWrapper/preprocess_fendl3.py
+++ b/tools/ALARAJOYWrapper/preprocess_fendl3.py
@@ -9,7 +9,7 @@ import logging
 from pathlib import Path
 from collections import defaultdict
 
-def args():
+def make_argparser():
     parser = argparse.ArgumentParser()
     parser.add_argument(
         '--decay_lib', '-d', required=True, nargs=1,
@@ -52,7 +52,16 @@ def args():
                 arise to a log file.
         ''')
     )
-    return parser.parse_args()
+    parser.add_argument(
+        '--group_structure', '-g', required=False, nargs=1,
+        help=('''
+            Specification for group structure in which to convert TENDL cross-
+                sections. See tendl_processing.set_group_structure() for
+                specific details for acceptable forms in which to supply this
+                argument.
+        ''')
+    )
+    return parser
 
 def configure_logging(redirect_warnings=False):
     """
@@ -146,8 +155,8 @@ def process_pendf(
     return MTs, isomer_dict, njoy_error
 
 def process_gendf(
-    njoy_groupr_input, material_id, MTs, mt_dict,
-    temperature, pKZA, isomer_dict, all_rxns, eaf_nucs
+    njoy_groupr_input, material_id, MTs, mt_dict, temperature, pKZA,
+    isomer_dict, all_rxns, eaf_nucs, ign=17, ngn='', egn=''
 ):
     """
     Prepare and run NJOY run with GROUPR and iteratively extract cross-section
@@ -184,6 +193,17 @@ def process_gendf(
             }
         eaf_nucs (dict): Dictionary keyed by all radionuclides in the EAF
             decay library, with values of their half-lives.
+        ign (str or int, optional): GROUPR neutron group structure parameter.
+            ign = 1 for arbitrary group structures not contained in NJOY's
+            built-in list of options. Default value corresponds to ign key for
+            the Vitamin-J 175 energy group structure.
+            (Defaults to 17)
+        ngn (str, optional): Number of groups. Will be an empty string unless
+            ign == 1.
+            (Defaults to '')
+        egn (str): Space-joined string of all energy group bounds in ascending
+            order. Will be an empty string unless ign == 1.
+            (Defaults to '')
 
     Returns:
         all_rxns (collections.defaultdict): Updated dictionary for all
@@ -193,7 +213,8 @@ def process_gendf(
     element, A = tp.interpret_KZA(pKZA)
     groupr_input = njt.fill_input_template(
         njoy_groupr_input, material_id, MTs, element,
-        A, mt_dict, temperature, pKZA, isomer_dict
+        A, mt_dict, temperature, pKZA, isomer_dict,
+        ign=ign, ngn=ngn, egn=egn
     )
     njt.write_njoy_input_file(groupr_input)
     gendf_path, njoy_error = njt.run_njoy(
@@ -203,7 +224,7 @@ def process_gendf(
     if gendf_path:
         # Extract MT values again from GENDF file as there may be some
         # difference from the original MT values in the ENDF/PENDF files
-        xs_line_dict, gendf_MTs = tp.extract_gendf_data(gendf_path)
+        xs_line_dict, gendf_MTs, nGroups = tp.extract_gendf_data(gendf_path)
         if MTs != gendf_MTs:
             diffs = sorted(MTs - gendf_MTs)
             warnings.warn(
@@ -213,7 +234,7 @@ def process_gendf(
         if gendf_MTs:
             all_rxns = tp.iterate_MTs(
                 gendf_MTs, mt_dict, xs_line_dict, pKZA, 
-                all_rxns, eaf_nucs, isomer_dict, gendf_path
+                all_rxns, eaf_nucs, isomer_dict, nGroups
             )
             print(f'Finished processing {element}-{A}')
 
@@ -231,7 +252,7 @@ def process_gendf(
             NJOY error message: {njoy_error}'''
         )
 
-    return all_rxns
+    return all_rxns, nGroups
 
 def subtract_gas_from_totals(all_rxns):
     """
@@ -274,7 +295,7 @@ def subtract_gas_from_totals(all_rxns):
 
     return all_rxns
 
-def combine_daughter_pathways(gas_filtered):
+def combine_daughter_pathways(gas_filtered, nGroups):
     """
     Calculate cumulative cross-sections from all reaction pathways that
         produce like daughters.
@@ -293,8 +314,8 @@ def combine_daughter_pathways(gas_filtered):
     for parent in gas_filtered:
         for daughter, rxn_list in gas_filtered[parent].items():
             collapsed = {
-                'emitted'    :                                 set(),
-                'xsections'  :  np.zeros(tp.VITAMIN_J_ENERGY_GROUPS)
+                'emitted'    :  set(),
+                'xsections'  :  np.zeros(nGroups)
             }
 
             for rxn in rxn_list.values():
@@ -325,7 +346,7 @@ def rxn_to_str(parent, daughter, rxn):
 
     return dsv_row
 
-def write_dsv(dsv_path, all_rxns):
+def write_dsv(dsv_path, all_rxns, nGroups):
     """
     Write out a space-delimited DSV file from the list of dictionaries,
         dsv_path, produced by iterating through each reaction of each isotope
@@ -355,7 +376,7 @@ def write_dsv(dsv_path, all_rxns):
     """
 
     with open(dsv_path, 'w') as dsv:
-        dsv.write(str(tp.VITAMIN_J_ENERGY_GROUPS) + '\n')
+        dsv.write(str(nGroups) + '\n')
         for parent in sorted(all_rxns):
             for daughter in all_rxns[parent]:
                 if parent != daughter:
@@ -370,22 +391,26 @@ def main():
     Main method when run as a command line script.
     """
 
+    argparser = make_argparser()
+    args = argparser.parse_args()
+
     warnings.formatwarning = (
         lambda msg, cat, fname, lineno, file=None, line=None:
             f"{Path(fname).name}:{lineno}: {cat.__name__}: {msg}\n"
     )
-    configure_logging(args().redirect_warnings)
+    configure_logging(args.redirect_warnings)
 
     TAPE20 = Path('tape20')
 
     dir = njt.set_directory()
     search_dir = (
-        Path(args().fendlFileDir[0]) if args().fendlFileDir else dir
-        )
-    temperature = args().temperature[0]
+        Path(args.fendlFileDir[0]) if args.fendlFileDir else dir
+    )
+    temperature = args.temperature[0]
+    ign, ngn, egn = njt.set_group_structure(args.group_structure)
 
     mt_dict = rxd.process_mt_data(rxd.load_mt_table(dir / 'mt_table.csv'))
-    eaf_nucs = rxd.find_eaf_ref_data(Path(args().decay_lib[0]))
+    eaf_nucs = rxd.find_eaf_ref_data(Path(args.decay_lib[0]))
     all_rxns = defaultdict(lambda: defaultdict(dict))
 
     for file_properties in tp.search_for_files(search_dir):
@@ -408,9 +433,10 @@ def main():
         )
 
         if not njoy_prep_error:
-            all_rxns = process_gendf(
+            all_rxns, nGroups = process_gendf(
                 njt.groupr_input, material_id, MTs, mt_dict,
-                temperature, pKZA, isomer_dict, all_rxns, eaf_nucs 
+                temperature, pKZA, isomer_dict, all_rxns, eaf_nucs,
+                ign=ign, ngn=ngn, egn=egn
             )
 
         else:
@@ -424,11 +450,11 @@ def main():
     # Handle gas total production cross-sections, per user specifications
     gas_filtered = subtract_gas_from_totals(all_rxns)
 
-    if args().amalgamate:
-        gas_filtered = combine_daughter_pathways(gas_filtered)
+    if args.amalgamate:
+        gas_filtered = combine_daughter_pathways(gas_filtered, nGroups)
 
     dsv_path = dir / 'cumulative_gendf_data.dsv'
-    write_dsv(dsv_path, gas_filtered)
+    write_dsv(dsv_path, gas_filtered, nGroups)
     print(f'Reaction data saved to: {dsv_path}')
 
 if __name__ == '__main__':

--- a/tools/ALARAJOYWrapper/preprocess_fendl3.py
+++ b/tools/ALARAJOYWrapper/preprocess_fendl3.py
@@ -223,7 +223,10 @@ def process_gendf(
     if gendf_path:
         # Extract MT values again from GENDF file as there may be some
         # difference from the original MT values in the ENDF/PENDF files
-        xs_line_dict, gendf_MTs, nGroups = tp.extract_gendf_data(gendf_path)
+        non_zero_xs, gendf_MTs, nGroups = tp.extract_gendf_data(
+            gendf_path, material_id
+        )
+
         if MTs != gendf_MTs:
             diffs = sorted(MTs - gendf_MTs)
             warnings.warn(
@@ -232,7 +235,7 @@ def process_gendf(
             )
         if gendf_MTs:
             all_rxns = tp.iterate_MTs(
-                gendf_MTs, mt_dict, xs_line_dict, pKZA, 
+                gendf_MTs, mt_dict, non_zero_xs, pKZA, 
                 all_rxns, eaf_nucs, isomer_dict, nGroups
             )
             print(f'Finished processing {element}-{A}')
@@ -444,7 +447,7 @@ def main():
                 NJOY error message: {njoy_prep_error}'''
             )
 
-        njt.cleanup_njoy_files(element, A)
+        #njt.cleanup_njoy_files(element, A)
 
     # Handle gas total production cross-sections, per user specifications
     gas_filtered = subtract_gas_from_totals(all_rxns)

--- a/tools/ALARAJOYWrapper/preprocess_fendl3.py
+++ b/tools/ALARAJOYWrapper/preprocess_fendl3.py
@@ -447,7 +447,7 @@ def main():
                 NJOY error message: {njoy_prep_error}'''
             )
 
-        #njt.cleanup_njoy_files(element, A)
+        njt.cleanup_njoy_files(element, A)
 
     # Handle gas total production cross-sections, per user specifications
     gas_filtered = subtract_gas_from_totals(all_rxns)

--- a/tools/ALARAJOYWrapper/preprocess_fendl3.py
+++ b/tools/ALARAJOYWrapper/preprocess_fendl3.py
@@ -223,9 +223,7 @@ def process_gendf(
     if gendf_path:
         # Extract MT values again from GENDF file as there may be some
         # difference from the original MT values in the ENDF/PENDF files
-        non_zero_xs, gendf_MTs, nGroups = tp.extract_gendf_data(
-            gendf_path, material_id
-        )
+        non_zero_xs, gendf_MTs, nGroups = tp.extract_gendf_data(gendf_path)
 
         if MTs != gendf_MTs:
             diffs = sorted(MTs - gendf_MTs)

--- a/tools/ALARAJOYWrapper/tendl_processing.py
+++ b/tools/ALARAJOYWrapper/tendl_processing.py
@@ -7,7 +7,6 @@ from collections import defaultdict
 import warnings
 import numpy as np
 
-VITAMIN_J_ENERGY_GROUPS = 175
 EXCITATION_DICT = {
     4   : np.arange(51 ,  92), # (n,n*)  reactions
     103 : np.arange(600, 650), # (n,p*)  reactions
@@ -285,6 +284,8 @@ def extract_gendf_data(gendf_path):
             the parsed GENDF file containing cross-section data.
          MTs (set of ints): All reaction types with cross-section data in the
             provided GENDF.
+        nGroups (int): Number of energy groups into which the groupwise cross
+            sections were calculated.
     """
 
     MTs = set()
@@ -292,10 +293,17 @@ def extract_gendf_data(gendf_path):
     current_section_lines = []
     current_MT = None
     line_count = 0
+    nGroups = None
 
     with open(gendf_path, 'r') as f:
         for line in f:
             mf, mt = _gendf_parse_control(line)
+            
+            # Extract number of groups, found in second line of file
+            # description section
+            if mf == 1 and mt == 451 and int(line.rstrip('\n')[-3:]) == 2:
+               nGroups = int(line.split()[2])
+
             if mf == 3 and mt != 0:
                 MTs.add(mt)
                 if mt != current_MT:
@@ -317,9 +325,15 @@ def extract_gendf_data(gendf_path):
                 current_MT = None
                 line_count = 0
 
-    return xs_line_dict, MTs
+    if nGroups is None:
+        raise ValueError(
+            f'{gendf_path} misformatted. Expecting to find group number in ' \
+            'MF1, MT451.'
+        )
 
-def process_xsections(xs_lines, M_values):
+    return xs_line_dict, MTs, nGroups
+
+def process_xsections(xs_lines, M_values, nGroups):
     """
     Given a list of lines containing all cross-section data for a given
         reaction type, identify all excitation pathways and save reformatted
@@ -333,11 +347,14 @@ def process_xsections(xs_lines, M_values):
             cross-section data.
         M_values (list of int): All possible isomeric states of the residual
             daughter produced from the given reaction type.
+        nGroups (int): Number of energy groups into which the groupwise cross
+            sections were calculated.
     
     Returns:
         sigma_dict (dict): Dictionary keyed by excitation levels (M) with
             values of padded NumPy arrays containing groupwise cross-sections
-            following the VITAMIN-J group structure.
+            following the group structure provided by the user or the default
+            Vitamin-J 175 group structure if none is otherwise specified.
     """
 
     sigma_dict = {}
@@ -353,9 +370,7 @@ def process_xsections(xs_lines, M_values):
             float(line.split(' ')[2].replace('+','E+').replace('-','E-'))
             for line in lines
         ][::-1]
-        sigma_dict[M] = np.pad(
-            sigmas, (0, VITAMIN_J_ENERGY_GROUPS - len(sigmas))
-        )
+        sigma_dict[M] = np.pad(sigmas, (0, nGroups - len(sigmas)))
     
     return sigma_dict
 
@@ -384,7 +399,7 @@ def incrementally_deexcite_isomer(M, dKZA, eaf_nucs):
     return dKZA + trial_M
 
 def iterate_MTs(
-    MTs, mt_dict, xs_line_dict, pKZA, all_rxns, eaf_nucs, isomer_dict, gendf_path
+    MTs, mt_dict, xs_line_dict, pKZA, all_rxns, eaf_nucs, isomer_dict, nGroups
 ):
     """
     Iterate through all of the MTs present in a given GENDF file to extract
@@ -423,8 +438,8 @@ def iterate_MTs(
             level has a list of all isomeric states of possible daughter
             nuclides for which there are cross-section data in the original
             TENDL file.
-        gendf_path (pathlib._local.PosixPath): Path to the GENDF file from
-            which to extract groupwise cross-sections.
+        nGroups (int): Number of energy groups into which the groupwise cross
+            sections were calculated.
             
     Returns:
         all_rxns (collections.defaultdict): Updated dictionary for all
@@ -440,7 +455,7 @@ def iterate_MTs(
     for MT in filtered_MTs:
         xs_lines = xs_line_dict[MT]
         M_values = list(isomer_dict[MT].values())[0]
-        isomer_specific_rxns = process_xsections(xs_lines, M_values)
+        isomer_specific_rxns = process_xsections(xs_lines, M_values, nGroups)
         rxn = mt_dict[MT]
         gas = rxn['gas']
         
@@ -481,13 +496,11 @@ def iterate_MTs(
                 if special_MT not in all_rxns[pKZA][dKZA]:
                     all_rxns[pKZA][dKZA][special_MT] = {
                         'emitted'  : emitted,
-                        'xsections': np.zeros(VITAMIN_J_ENERGY_GROUPS)
+                        'xsections': np.zeros(nGroups)
                     }
 
                 all_rxns[pKZA][dKZA][special_MT][
                     'xsections'
-                ] += np.pad(
-                    sigmas, (0, VITAMIN_J_ENERGY_GROUPS - len(sigmas))
-                )
+                ] += np.pad(sigmas, (0, nGroups - len(sigmas)))
 
     return all_rxns

--- a/tools/ALARAJOYWrapper/tendl_processing.py
+++ b/tools/ALARAJOYWrapper/tendl_processing.py
@@ -268,7 +268,7 @@ def _gendf_parse_control(line):
     except ValueError:
         return None, None
 
-def extract_gendf_data(gendf_path, material_id):
+def extract_gendf_data(gendf_path):
     """
     Parse a GENDF-formatted (post-GROUPR processing) file for lines containing
         cross-section data for each reaction type, while compiling a full set
@@ -277,8 +277,6 @@ def extract_gendf_data(gendf_path, material_id):
     Arguments
         gendf_path (pathlib._local.PosixPath): Path to the GENDF file from
              which to extract cross-section data.
-        material_id (int): Unique material ID of the parent nuclide catalogued
-            in the GENDF file.
 
     Returns:
         non_zero_xs (collections.defaultdict): Dictionary keyed by MT number
@@ -325,20 +323,18 @@ def extract_gendf_data(gendf_path, material_id):
                     continue
 
                 if line_count % 2 == 0:
-                    current_IG = int(
-                        line[:line.index(str(material_id))].split()[-1]
-                    )
+                    current_IG = int(line[62:66])
 
                 else:
                     current_section[current_IG] = float(
-                        line.split()[2].replace('+','E+').replace('-','E-')
+                        line.split()[1].replace('+','E+').replace('-','E-')
                     )
-            
+
             else:
                 if current_section:
                     non_zero_xs[current_MT].append(current_section)
                     current_section = {}
-                
+
                 current_MT = None
                 current_IG = None
                 line_count = 0

--- a/tools/ALARAJOYWrapper/tendl_processing.py
+++ b/tools/ALARAJOYWrapper/tendl_processing.py
@@ -268,20 +268,23 @@ def _gendf_parse_control(line):
     except ValueError:
         return None, None
 
-def extract_gendf_data(gendf_path):
+def extract_gendf_data(gendf_path, material_id):
     """
     Parse a GENDF-formatted (post-GROUPR processing) file for lines containing
         cross-section data for each reaction type, while compiling a full set
         of all MT numbers corresponding to that reaction.
 
     Arguments
-         gendf_path (pathlib._local.PosixPath): Path to the GENDF file from
+        gendf_path (pathlib._local.PosixPath): Path to the GENDF file from
              which to extract cross-section data.
+        material_id (int): Unique material ID of the parent nuclide catalogued
+            in the GENDF file.
 
     Returns:
-        xs_line_dict (collections.defaultdict): Dictionary keyed by MT number
-            with values of lists of all line strings in the MT-section from
-            the parsed GENDF file containing cross-section data.
+        non_zero_xs (collections.defaultdict): Dictionary keyed by MT number
+            valued by lists of sub-dictionaries. Each of these are keyed by
+                the GROUPR group index tag (`IG`) and valued by the associated
+                groupwise cross-section value for that energy group.
          MTs (set of ints): All reaction types with cross-section data in the
             provided GENDF.
         nGroups (int): Number of energy groups into which the groupwise cross
@@ -289,9 +292,11 @@ def extract_gendf_data(gendf_path):
     """
 
     MTs = set()
-    xs_line_dict = defaultdict(list)
-    current_section_lines = []
+    non_zero_xs = defaultdict(list)
+
     current_MT = None
+    current_section = {}
+    current_IG = None
     line_count = 0
     nGroups = None
 
@@ -307,22 +312,35 @@ def extract_gendf_data(gendf_path):
             if mf == 3 and mt != 0:
                 MTs.add(mt)
                 if mt != current_MT:
-                    if current_section_lines:
-                        xs_line_dict[current_MT].append(current_section_lines)
-                        current_section_lines = []
+                    if current_section:
+                        non_zero_xs[current_MT].append(current_section)
+                    
+                    current_section = {}
                     current_MT = mt
                     line_count = 0
 
                 line_count += 1
 
-                if line_count >= 3 and line_count % 2 == 1:
-                    current_section_lines.append(line)
+                if line_count < 2:
+                    continue
 
+                if line_count % 2 == 0:
+                    current_IG = int(
+                        line[:line.index(str(material_id))].split()[-1]
+                    )
+
+                else:
+                    current_section[current_IG] = float(
+                        line.split()[2].replace('+','E+').replace('-','E-')
+                    )
+            
             else:
-                if current_section_lines:
-                    xs_line_dict[current_MT].append(current_section_lines)
-                    current_section_lines = []
+                if current_section:
+                    non_zero_xs[current_MT].append(current_section)
+                    current_section = {}
+                
                 current_MT = None
+                current_IG = None
                 line_count = 0
 
     if nGroups is None:
@@ -331,20 +349,21 @@ def extract_gendf_data(gendf_path):
             'MF1, MT451.'
         )
 
-    return xs_line_dict, MTs, nGroups
+    return non_zero_xs, MTs, nGroups
 
-def process_xsections(xs_lines, M_values, nGroups):
+def populate_xs(xs_by_index, M_values, nGroups):
     """
-    Given a list of lines containing all cross-section data for a given
-        reaction type, identify all excitation pathways and save reformatted
-        and padded cross-section arrays to a dictionary keyed by isomeric
-        states (M). Each reaction type may have multiple actual reaction
-        pathways, corresponding to different isomeric states of the daughter,
-        which appear within the file in ascending order of excitation.
+    Given a dictionary containing all cross-section data for a given reaction
+        type, identify all excitation pathways and save group-positioned 
+        cross-section arrays to a dictionary keyed by isomeric states (M).
+        Each reaction type may have multiple actual reaction pathways,
+        corresponding to different isomeric states of the daughter, which
+        appear within the file in ascending order of excitation.
     
     Arguments:
-        xs_lines (line of str): List of all lines in the MT-section containing
-            cross-section data.
+        xs_by_index (dict): Dictionary of all non-zero cross-sections for a
+            given MT value keyed by the GROUPR group index tag (`IG`) and
+            valued by the groupwise cross-section in barns.
         M_values (list of int): All possible isomeric states of the residual
             daughter produced from the given reaction type.
         nGroups (int): Number of energy groups into which the groupwise cross
@@ -359,19 +378,19 @@ def process_xsections(xs_lines, M_values, nGroups):
 
     sigma_dict = {}
     excitations = len(M_values)
-    N = min(excitations, len(xs_lines))
-    
-    # If multiple excitations, M values equal the list indices of LFS values
+    N = min(excitations, len(xs_by_index))
+
     if excitations > 1:
         M_values = list(range(excitations))
 
-    for M, lines in zip(M_values[:N], xs_lines[:N]):
-        sigmas = [
-            float(line.split(' ')[2].replace('+','E+').replace('-','E-'))
-            for line in lines
-        ][::-1]
-        sigma_dict[M] = np.pad(sigmas, (0, nGroups - len(sigmas)))
-    
+    for M, ordered_xs in zip(M_values[:N], xs_by_index[:N]):
+        sigmas = np.zeros(nGroups)
+
+        for IG, sigma in ordered_xs.items():
+            sigmas[IG - 1] = sigma
+
+        sigma_dict[M] = sigmas[::-1]
+
     return sigma_dict
 
 def incrementally_deexcite_isomer(M, dKZA, eaf_nucs):
@@ -399,7 +418,7 @@ def incrementally_deexcite_isomer(M, dKZA, eaf_nucs):
     return dKZA + trial_M
 
 def iterate_MTs(
-    MTs, mt_dict, xs_line_dict, pKZA, all_rxns, eaf_nucs, isomer_dict, nGroups
+    MTs, mt_dict, non_zero_xs, pKZA, all_rxns, eaf_nucs, isomer_dict, nGroups
 ):
     """
     Iterate through all of the MTs present in a given GENDF file to extract
@@ -414,9 +433,11 @@ def iterate_MTs(
     
     Arguments:
         MTs (list of int): List of reaction types present in the GENDF file.
-        file_obj (ENDFtk.tree.File): ENDFtk file object containing the
-            contents for a specific material's cross-section data.
         mt_dict (dict): Dictionary formatted data structure for mt_table.csv
+        non_zero_xs (collections.defaultdict): Dictionary keyed by MT number
+            valued by lists of sub-dictionaries. Each of these are keyed by
+                the GROUPR group index tag (`IG`) and valued by the associated
+                groupwise cross-section value for that energy group.        
         pKZA (int): Parent KZA identifier.
         all_rxns (collections.defaultdict): Hierarchical dictionary keyed by
             parent nuclides to store all reaction data, with structured as:
@@ -453,14 +474,13 @@ def iterate_MTs(
             filtered_MTs.add(MT)
 
     for MT in filtered_MTs:
-        xs_lines = xs_line_dict[MT]
+        xs_by_index = non_zero_xs[MT]
         M_values = list(isomer_dict[MT].values())[0]
-        isomer_specific_rxns = process_xsections(xs_lines, M_values, nGroups)
         rxn = mt_dict[MT]
         gas = rxn['gas']
         
         # Calculate dKZA values for each excitation pathway in MF10
-        for M, sigmas in isomer_specific_rxns.items():
+        for M, sigmas in populate_xs(xs_by_index, M_values, nGroups).items():
             emitted = rxn['emitted']
             dKZA = (((pKZA // 10) * 10 + rxn['delKZA']) // 10) * 10 + M
             if gas:
@@ -499,8 +519,6 @@ def iterate_MTs(
                         'xsections': np.zeros(nGroups)
                     }
 
-                all_rxns[pKZA][dKZA][special_MT][
-                    'xsections'
-                ] += np.pad(sigmas, (0, nGroups - len(sigmas)))
+                all_rxns[pKZA][dKZA][special_MT]['xsections'] += sigmas
 
     return all_rxns


### PR DESCRIPTION
This PR updates the `ALARAJOYWrapper` preprocessor to allow for a user to convert TENDL cross section data to groupwise cross-sections with multi-group energy group structures beyond Vitamin-J. The motivation for this update is twofold. First, when comparing against FISPACT-II for our validation efforts, in order to minimize differences between ALARA and FISPACT-II, which is primarily designed to use the CCFE-709 group structure, it would be valuable to compare cross-sections with like-structures. FISPACT-II is capable of applying other group structures as well, but my second consideration in motivating this PR is that I think it would be valuable in general for users to be able to specify their desired group structure, without dictating that Vitamin-J is the only valid option, considering that ALARA can use other group structures already. Whether or not we choose to apply this update for the validation efforts in producing a 709 group ALARAJOY library can be decided separately, but I still think an update like this will be a generally helpful feature.

The primary update that I introduced in this PR is a new function `njoy_tools.set_group_structure()`, which takes in an optional user argument for the group structure and prepares the proper format of `GROUPR` parameters to convert to the provided cross-sections. In the docstring for that function, I specify the types and ways this can be done:

> Interpret the group_structure argument (`-g`) to define the requisite NJOY
>        parameters to convert TENDL data to the given multi-group energy
>       structure. By default, the Vitamin-J 175 group structure is used for
>        ALARAJOY preprocessing and this function will return the appropriate
>        values for NJOY to run GROUPR with these settings. If another group
>       structure is desired, however, there are three ways in which this
>        group structure can be set:
>
>       1) Provide the GROUPR `ign` key corresponding to the desired group
>        structure. NJOY has 33 built-in group structures from which GROUPR can
>        access their data, including for Vitamin-J. These can be found in
>        Section 8.18 ("Running GROUPR") of the NJOY User Manual
>        (https://github.com/njoy/NJOY2016-manual/raw/master/njoy16.pdf).
>
>        2) Provide a support file containing the explicit energy bounds of a
>        multi-group energy structure. NJOY is not limited to its pre-set
>        structures, and is capable of converting cross-sections to an
>        arbitrary group structure, so long as the energy bounds and number of
>        groups are provided. To use this option format the support file as:
>
>            BOUND_1
>            BOUND_2
>            ...
>            BOUND_N
>        
>        The order in the support file can be arbitrary because after being
>        read in, the values will be sorted to ensure compliance to NJOY's
>        expectation of ascending energy bounds for an arbitrary group
>        structure.
>
>        3) Provide a group-structure name corresponding to a key in the
>        `openmc.mgxs.GROUP_STRUCTURES` dictionary. The open-source Monte Carlo
>        neutron transport code OpenMC contains a number of multi-group energy
>        structures that may be applicable for activation studies but are not
>        included in the list of NJOY options mentioned in `(1)`, such as the
>        'CCFE-709' group structure used by FISPACT-II. These group structures
>        can be found at https://docs.openmc.org/en/stable/pythonapi/mgxs.html.
