### PR TITLE
Introducing Comparative Cross-Section Plotting Module

### DIFF
--- a/src/DataLib/ALARAJOY.cpp
+++ b/src/DataLib/ALARAJOY.cpp
@@ -33,14 +33,20 @@ void ALARAJOYLib::loadDSVData()
     currentParent = -1;
     DSVRow row;
 
-    // Read header containing energy group number
-    inTrans >> nGroups;
+    // Read header containing energy group number in first entry
+    std::string headerLine;
+    std::getline(inTrans, headerLine);
+    std::istringstream headerStream(headerLine);
+    headerStream >> nGroups;
 
     // Extract Parent KZA until EOF at pKZA == -1
     while ((inTrans >> row.parentKZA) && row.parentKZA != -1)
     {
-        // Extract Daughter KZA, emitted particles, and non-zero groups
-        inTrans >> row.daughterKZA >> row.emittedParticles;
+        // Store MT as temporary variable
+        int MT;
+
+        // Extract Daughter KZA, emitted particles, non-zero groups; pass MT
+        inTrans >> row.daughterKZA >> MT >> row.emittedParticles;
 
         /* Iterate through rest of line for cross sections 
            based on non-zero groups*/

--- a/tools/ALARAJOYWrapper/README.md
+++ b/tools/ALARAJOYWrapper/README.md
@@ -19,6 +19,7 @@ This preprocessor uses [NJOY 2016](https://github.com/njoy/NJOY2016) Nuclear Dat
 - Generic Python packages
   * [NumPy](https://numpy.org/install/)
   * [Pandas](https://pandas.pydata.org/docs/getting_started/install.html)
+  * [PyYAML](https://pyyaml.org/wiki/PyYAMLDocumentation) (only needed if running `spectra_plotting.py` as an independent script.)
 - Domain-specific packages
   * [ENDFtk](https://github.com/njoy/ENDFtk)
   * [NJOY 2016](https://github.com/njoy/NJOY2016) (built with `develop` branch)
@@ -34,7 +35,7 @@ To run this preprocessor, the user must first have acquired TENDL files for each
 
 Running ALARAJOYWrapper can be done with one Python command:
 ```
-python preprocess_fendl3.py -f /path/to/fendl3_data_dir/ -d /path/to/eaf_decay_library/ -a -t -r -g
+python preprocess_fendl3.py -f /path/to/fendl3_data_dir/ -d /path/to/eaf_decay_library/ -a -t -r -g -p
 ```
 To read in detail about each of these arguments, call this command:
 ```
@@ -62,6 +63,80 @@ Running `preprocess_fendl3.py` will return the file path to the resultant space-
 - Cross Sections: List of all non-zero neutron cross sections.
 
 It should be noted that TENDL 2017 activation data contains many reactions that leave the residual nucleus in various quantized excited states, potentially up to a 40<sup>th</sup> excited state. Most of these daughter isomers, however, are extremely short-lived and lack decay data. When converting an ALARAJOY DSV file in ALARA, as discussed below, an EAF decay library is required, given that FENDL3.2x only contains activation data. Cross-referencing exotic isomers against this decay data ensures that ultra-short-lived reaction products are not passed on to ALARA's library conversion appearing as stable nuclides. Rather, the lack of decay data signifies such a short half-life that decay evaluations are not practical. For excited daughter nuclides produced from a given reaction lacking corresponding EAAF decay data, ALARAJOY will incrementally de-excite the nuclear state one-by-one down to the next lowest energy level with known decay data (or ultimately to ground).
+
+## Neutron Cross-Section Plotting
+The conversion of neutron cross-sections from a continuous energy form to a groupwise form according to some multigroup energy structure necessarily makes approximations to the data. Visualizing groupwise cross-sections against continous TENDL data can be useful in fundamental validation of the conversion methods employed by ALARAJOY and to understand the effects of different choices of group structures on the final form of groupwise data to be used within ALARA.
+
+Either as an optional inclusion within the main ALARAJOY groupwise processing pipeline or as a standalone tool, cross-sections can be plotted to compare groupwise cross-sections with continous-energy values contained in the orignal TENDL files with `xs_plotting.py`. The core functionality is contained in `xs_plotting.plot_cross_sections()`, which produces plots for each nuclide/reaction combination to be assessed, with additional capacity to overlay multiple different DSV data sources from ALARAJOY conversions with different group structures. These plots are saved according to the following structure:
+
+  ```
+  TENDL_DATA_SOURCE
+    ⤷ ELEMENT
+      ⤷ NUCLIDE
+        ⤷ REACTION_1
+        ⤷ ...
+        ⤷ REACTION_N
+  ```
+
+When the optional `-p` argument is invoked when executing `preprocess_fendl3.py`, all reactions for all nuclides written out to `cumulative_gendf_data.dsv` will be produced and saved according to the above directory structure. The highest level directory will be the same name as the `-f` TENDL data directory, with an additional "`_plots`" tag (e.g. `tendl2017/` → `tendl2017_plots/`).
+
+To run `xs_plotting.py` as a standalone script, an input `.yaml` file must be supplied to specify the nuclides and reactions to be plotted. Additionally, the groupwise and continuous data sources to comparatively plot can be specified in this input file. These, however, are not required and will default to `cumulative_gendf_data.dsv` and `tendl2017/` respectively. The format of this input is shown below, as well as in `example_xs_plotting_input.yaml`, which can be used as a basis to supply custom plotting parameters according to their needs. Reactions are specified by their MT number, whose reference can be found at https://www.oecd-nea.org/dbdata/data/manual-endf/endf102_MT.pdf. 
+
+```
+# Option to specify arbitrary number of groupwise data sources
+# Default: cumulative_gendf_data.dsv
+DSV:
+  - groupwise_struct_1.dsv # (e.g. vitamin_j_175.dsv)
+  - groupwise_struct_2.dsv # (e.g. ccfe_709.dsv)
+  - ...
+  - groupwise_struct_n.dsv
+
+# Option to specify the TENDL data source from which groupwise data were produced
+# Default: tendl2017/
+TENDL:
+  - tendl_directory/
+
+# Reactions specified by ELEMENT → MASS NUMBER → REACTIONS
+# ELEMENT_1:
+#   A_1:
+#     - REACTION_1_1
+#     - ...
+#     - REACTION_1_N
+#   ...
+#   A_N:
+#     - REACTION_N_1
+#     - ...
+#     - REACTION_N_N
+
+Fe:
+  54:
+    - 16  # (n,2n)
+    - 102 # (n,g)
+  55:
+    - 103 # (n,p)
+  56:
+    - 203 # (n,Xp)
+
+W:
+  all: # Iterates through all W nuclides
+    - 205 # (n,Xt)
+
+C:
+  12:
+    - all # Iterates through all C-12 reactions
+
+N:
+  all:
+    - all
+```
+
+Using parameter `all` for any category of element, mass number, or reaction will iterate through all possible values of that parameter and produce plots accordingly, which can be done for any or all of these parameters, together or individually.
+
+The cross-section plotting script is run as follows:
+
+```
+python xs_plotting.py -y /path/to/input_file.yaml
+```
 
 ## Application of Processed Data to ALARA Data Conversion Methods
 Data library conversion to ALARA binary libraries is done with the `convert_lib` input block in the ALARA input file. Converting preprocessed TENDL data contained in the resultant space-delimited DSV from ALARAJOYWrapper is done as such in the input file:

--- a/tools/ALARAJOYWrapper/README.md
+++ b/tools/ALARAJOYWrapper/README.md
@@ -22,6 +22,7 @@ This preprocessor uses [NJOY 2016](https://github.com/njoy/NJOY2016) Nuclear Dat
 - Domain-specific packages
   * [ENDFtk](https://github.com/njoy/ENDFtk)
   * [NJOY 2016](https://github.com/njoy/NJOY2016) (built with `develop` branch)
+  * [OpenMC](https://docs.openmc.org/en/stable/quickinstall.html) (only needed if specifying a multigroup energy structure by name from the dictionary `openmc.mgxs.GROUP_STRUCTURES`)
 
 
 ## Usage
@@ -33,7 +34,7 @@ To run this preprocessor, the user must first have acquired TENDL files for each
 
 Running ALARAJOYWrapper can be done with one Python command:
 ```
-python preprocess_fendl3.py -f /path/to/fendl3_data_dir/ -d /path/to/eaf_decay_library/ -a -t -r
+python preprocess_fendl3.py -f /path/to/fendl3_data_dir/ -d /path/to/eaf_decay_library/ -a -t -r -g
 ```
 To read in detail about each of these arguments, call this command:
 ```

--- a/tools/ALARAJOYWrapper/example_xs_plotting_input.yaml
+++ b/tools/ALARAJOYWrapper/example_xs_plotting_input.yaml
@@ -1,0 +1,45 @@
+# Option to specify arbitrary number of groupwise data sources
+# Default: cumulative_gendf_data.dsv
+DSV:
+  - groupwise_struct_1.dsv # (e.g. vitamin_j_175.dsv)
+  - groupwise_struct_2.dsv # (e.g. ccfe_709.dsv)
+  - ...
+  - groupwise_struct_n.dsv
+
+# Option to specify the TENDL data source from which groupwise data were produced
+# Default: tendl2017/
+TENDL:
+  - tendl_directory/
+
+# Reactions specified by ELEMENT → MASS NUMBER → REACTIONS
+# ELEMENT_1:
+#   A_1:
+#     - REACTION_1_1
+#     - ...
+#     - REACTION_1_N
+#   ...
+#   A_N:
+#     - REACTION_N_1
+#     - ...
+#     - REACTION_N_N
+
+Fe:
+  54:
+    - 16  # (n,2n)
+    - 102 # (n,g)
+  55:
+    - 103 # (n,p)
+  56:
+    - 203 # (n,Xp)
+
+W:
+  all: # Iterates through all W nuclides
+    - 205 # (n,Xt)
+
+C:
+  12:
+    - all # Iterates through all C-12 reactions
+
+N:
+  all:
+    - all

--- a/tools/ALARAJOYWrapper/njoy_tools.py
+++ b/tools/ALARAJOYWrapper/njoy_tools.py
@@ -164,11 +164,12 @@ def set_group_structure(group_struct_arg):
         structure is desired, however, there are three ways in which this
         group structure can be set:
 
-        1) Provide the GROUPR `ign` key corresponding to the desired group
-        structure. NJOY has 33 built-in group structures from which GROUPR can
-        access their data, including for Vitamin-J. These can be found in
-        Section 8.18 ("Running GROUPR") of the NJOY User Manual
-        (https://github.com/njoy/NJOY2016-manual/raw/master/njoy16.pdf).
+        1) Provide the GROUPR `ign` key or group name corresponding to the
+        desired group structure. NJOY has 33 built-in group structures from
+        which GROUPR can access their data, including for Vitamin-J. These can
+        be found in Section 8.18 ("Running GROUPR") of the NJOY User Manual
+        (https://github.com/njoy/NJOY2016-manual/raw/master/njoy16.pdf) or in
+        the dictionary njoy_tools.NJOY_GROUPS.
 
         2) Provide a support file containing the explicit energy bounds of a
         multi-group energy structure. NJOY is not limited to its pre-set
@@ -195,14 +196,13 @@ def set_group_structure(group_struct_arg):
         can be found at https://docs.openmc.org/en/stable/pythonapi/mgxs.html.
     
     Arguments:
-        group_struct_arg (None or list of str): Group structure argument
-            following procedures described above or None, if default
-            Vitamin-J 175 group structure settings to be applied.
+        group_struct_arg (list of str): Group structure argument following the 
+            procedures described above.
 
     Returns:
-        ign (str or int): GROUPR neutron group structure parameter. ign = 1
-            for arbitrary group structures not contained in NJOY's built-in
-            list of options.
+        ign (int): GROUPR neutron group structure parameter. ign = 1 for
+            arbitrary group structures not contained in NJOY's built-in list
+            of options.
         ngn (str): Number of groups. Will be an empty string unless ign == 1.
         egn (str): Space-joined string of all energy group bounds in
             ascending order. Will be an empty string unless ign == 1.
@@ -211,47 +211,48 @@ def set_group_structure(group_struct_arg):
 
     ngn = ''
     egn = ''
+    group_struct = group_struct_arg[0]
 
-    # Default to Vitamin-J group structure if none is provided from args
-    if group_struct_arg is None:
-        ign = 17
-        group_name = 'VITAMIN-J-175'
+    # Check if provided group structure is among the list of built-in NJOY
+    # group structures by key (ign values 2-34)
+    if group_struct in np.array(list(NJOY_GROUPS)).astype(str):
+        ign = int(group_struct)
+        group_name = NJOY_GROUPS[ign]
 
+    # Check if provided group structure is among the list of built-in NJOY
+    # group structures by name (values of NJOY_GROUPS dict)
+    elif group_struct.upper() in NJOY_GROUPS.values():
+        group_name = group_struct.upper()
+        ign = list(NJOY_GROUPS.keys())[
+            list(NJOY_GROUPS.values()).index(group_name)
+        ]
+
+    # NJOY "arbitrary group structure" option
     else:
-        group_struct = group_struct_arg[0]
+        ign = 1
+        group_bounds = []
+        # If support file containing group bounds is provided, load them
+        # into an array
+        if Path(group_struct).is_file():
+            group_bounds = np.loadtxt(group_struct)
+            group_name = f'CUSTOM-{len(group_bounds)}'
 
-        # Check if provided group structure is among the list of built-in NJOY
-        # group structures (ign values 2-34)
-        if group_struct in np.array(list(NJOY_GROUPS)).astype(str):
-            ign = group_struct
-            group_name = NJOY_GROUPS[int(group_struct)]
-
-        # NJOY "arbitrary group structure" option
+        # If group structure name is provided, extract values from OpenMC
         else:
-            ign = 1
-            group_bounds = []
-            # If support file containing group bounds is provided, load them
-            # into an array
-            if Path(group_struct).is_file():
-                group_bounds = np.loadtxt(group_struct)
-                group_name = f'CUSTOM-{len(group_bounds)}'
+            from openmc.mgxs import GROUP_STRUCTURES
+            group_name = group_struct.upper()
+            group_bounds = GROUP_STRUCTURES.get(group_name, [])
 
-            # If group structure name is provided, extract values from OpenMC
-            else:
-                from openmc.mgxs import GROUP_STRUCTURES
-                group_name = group_struct.upper()
-                group_bounds = GROUP_STRUCTURES.get(group_name, [])
-
-            if len(group_bounds) == 0:
-                raise ValueError(
-                    'Invalid group structure provided. Must either be an '  \
-                    'ign value known by NJOY, a group structure name in '   \
-                    '`openmc.mgxs.GROUP_STRUCTURES`, or a file containing ' \
-                    'explicit energy group bounds.'
-                )
-            
-            ngn = str(len(group_bounds) - 1)
-            egn = ' '.join(np.array(sorted(group_bounds)).astype(str))
+        if len(group_bounds) == 0:
+            raise ValueError(
+                'Invalid group structure provided. Must either be an '  \
+                'ign value known by NJOY, a group structure name in '   \
+                '`openmc.mgxs.GROUP_STRUCTURES`, or a file containing ' \
+                'explicit energy group bounds.'
+            )
+        
+        ngn = str(len(group_bounds) - 1)
+        egn = ' '.join(np.array(sorted(group_bounds)).astype(str))
 
     return ign, ngn, egn, group_name
 

--- a/tools/ALARAJOYWrapper/njoy_tools.py
+++ b/tools/ALARAJOYWrapper/njoy_tools.py
@@ -235,7 +235,9 @@ def set_group_structure(group_struct_arg):
         # into an array
         if Path(group_struct).is_file():
             group_bounds = np.loadtxt(group_struct)
-            group_name = f'CUSTOM-{len(group_bounds)}'
+            group_name = 'user-provided ' + (
+                f'{Path(group_struct).stem.upper()}-{len(group_bounds) - 1}'
+            )
 
         # If group structure name is provided, extract values from OpenMC
         else:

--- a/tools/ALARAJOYWrapper/njoy_tools.py
+++ b/tools/ALARAJOYWrapper/njoy_tools.py
@@ -3,6 +3,7 @@ from string import Template
 import subprocess
 from pathlib import Path
 import re
+import numpy as np
 
 def set_directory():
     '''
@@ -75,10 +76,12 @@ groupr_input = Template(Template(
 """
 groupr/
  $NENDF $NPEND $NGOUT1 $NGOUT2/
- $mat_id $IGN $IGG $IWT $LORD $NTEMP $NSIGZ $IPRINT_groupr/
+ $mat_id $ign $IGG $IWT $LORD $NTEMP $NSIGZ $IPRINT_groupr/
  $title/
  $groupr_temp
  $SIGZ_groupr/
+ $ngn
+ $egn
  $reactions
  $MATD/
  0/
@@ -89,7 +92,6 @@ stop
     NPEND = 25,         # unit for final PENDF tape (equivalent to NOUT_gaspr)
     NGOUT1 = 0,                         # unit for input gout tape (default=0)
     NGOUT2 = 31,                       # unit for output gout tape (default=0)
-    IGN = 17,    # neutron group structure option (corresponding to Vitamin J)
     IGG = 0,                                    # gamma group structure option
     IWT = 11,            # weight function option (corresponding to Vitamin E)
     LORD = 0,                                                 # Legendre order
@@ -115,6 +117,102 @@ elements = [
     'Rg', 'Cn', 'Nh', 'Fl', 'Mc', 'Lv', 'Ts', 'Og'
 ]
 elements = dict(zip(elements, range(1, len(elements)+1)))
+
+def set_group_structure(group_struct_arg):
+    """
+    Interpret the group_structure argument (`-g`) to define the requisite NJOY
+        parameters to convert TENDL data to the given multi-group energy
+        structure. By default, the Vitamin-J 175 group structure is used for
+        ALARAJOY preprocessing and this function will return the appropriate
+        values for NJOY to run GROUPR with these settings. If another group
+        structure is desired, however, there are three ways in which this
+        group structure can be set:
+
+        1) Provide the GROUPR `ign` key corresponding to the desired group
+        structure. NJOY has 33 built-in group structures from which GROUPR can
+        access their data, including for Vitamin-J. These can be found in
+        Section 8.18 ("Running GROUPR") of the NJOY User Manual
+        (https://github.com/njoy/NJOY2016-manual/raw/master/njoy16.pdf).
+
+        2) Provide a support file containing the explicit energy bounds of a
+        multi-group energy structure. NJOY is not limited to its pre-set
+        structures, and is capable of converting cross-sections to an
+        arbitrary group structure, so long as the energy bounds and number of
+        groups are provided. To use this option format the support file as:
+
+            BOUND_1
+            BOUND_2
+            ...
+            BOUND_N
+        
+        The order in the support file can be arbitrary because after being
+        read in, the values will be sorted to ensure compliance to NJOY's
+        expectation of ascending energy bounds for an arbitrary group
+        structure.
+
+        3) Provide a group-structure name corresponding to a key in the
+        `openmc.mgxs.GROUP_STRUCTURES` dictionary. The open-source Monte Carlo
+        neutron transport code OpenMC contains a number of multi-group energy
+        structures that may be applicable for activation studies but are not
+        included in the list of NJOY options mentioned in `(1)`, such as the
+        'CCFE-709' group structure used by FISPACT-II. These group structures
+        can be found at https://docs.openmc.org/en/stable/pythonapi/mgxs.html.
+    
+    Arguments:
+        group_struct_arg (None or list of str): Group structure argument
+            following procedures described above or None, if default
+            Vitamin-J 175 group structure settings to be applied.
+
+    Returns:
+        ign (str): GROUPR neutron group structure parameter. ign = 1 for
+            arbitrary group structures not contained in NJOY's built-in list
+            of options.
+        ngn (str): Number of groups. Will be an empty string unless ign == 1.
+        egn (str): Space-joined string of all energy group bounds in
+            ascending order. Will be an empty string unless ign == 1.
+    """
+
+    ngn = ''
+    egn = ''
+
+    # Default to Vitamin-J group structure if none is provided from args
+    if group_struct_arg is None:
+        ign = 17 # NJOY flag for Vitamin-J
+
+    else:
+        group_struct = group_struct_arg[0]
+
+        # Check if provided group structure is among the list of built-in NJOY
+        # group structures (ign values 2-34)
+        if group_struct in range(2,35):
+            ign = group_struct
+
+        # NJOY "arbitrary group structure" option
+        else:
+            ign = 1
+            group_bounds = []
+            # If support file containing group bounds is provided, load them
+            # into an array
+            if Path(group_struct).is_file():
+                group_bounds = np.loadtxt(group_struct)
+
+            # If group structure name is provided, extract values from OpenMC
+            else:
+                from openmc.mgxs import GROUP_STRUCTURES
+                group_bounds = GROUP_STRUCTURES.get(group_struct.upper(), [])
+
+            if len(group_bounds) == 0:
+                raise ValueError(
+                    'Invalid group structure provided. Must either be an '  \
+                    'ign value known by NJOY, a group structure name in '   \
+                    '`openmc.mgxs.GROUP_STRUCTURES`, or a file containing ' \
+                    'explicit energy group bounds.'
+                )
+            
+            ngn = str(len(group_bounds) - 1)
+            egn = ' '.join(np.array(sorted(group_bounds)).astype(str))
+
+    return ign, ngn, egn
 
 def card9_special_isomer_reactions(pKZA, MT, mt_data, isomer_data, mtname):
     """
@@ -168,7 +266,7 @@ def card9_special_isomer_reactions(pKZA, MT, mt_data, isomer_data, mtname):
 
 def fill_input_template(
     inp, material_id, MTs, element, A, mt_dict, temperature,
-    pKZA=None, isomer_dict={}
+    pKZA=None, isomer_dict={}, ign=17, ngn='', egn=''
 ):
     """
     Substitute in the material-specific values for a given ENDF/PENDF file
@@ -201,12 +299,38 @@ def fill_input_template(
             states of the residual daughter. Only needed when filling the
             GROUPR-specific template.
             (Defaults to {})
+        ign (str or int, optional): GROUPR neutron group structure parameter.
+            ign = 1 for arbitrary group structures not contained in NJOY's
+            built-in list of options. Default value corresponds to ign key for
+            the Vitamin-J 175 energy group structure.
+            (Defaults to 17)
+        ngn (str, optional): Number of groups. Will be an empty string unless
+            ign == 1.
+            (Defaults to '')
+        egn (str): Space-joined string of all energy group bounds in ascending
+            order. Will be an empty string unless ign == 1.
+            (Defaults to '')
     
     Returns:
         template (str): Modified template with the material-
             specific information substituted in for the $identifiers,
             converted to a string.
     """
+
+    # Card 6 special handling for explicitly defined energy groups
+    if ign == 1:
+        if not ngn or not egn:
+            raise ValueError(
+                'In order to convert to arbitrary group structure ' \
+                '(ign == 1), GROUPR requires the number of groups (ngn) and' \
+                ' the group boundaries (egn).\nWhen using njoy_tools within ' \
+                'preprocess_fendl3.py, either include a group structure ' \
+                'defined in openmc.mgxs.GROUP_STRUCTURES or provide a file ' \
+                'as a second value for the -g argument that explicitly ' \
+                'lists the group boundaries.'
+            )
+        ngn += ' /'
+        egn += ' /'
 
     Z = str(elements[element]).zfill(2)
     title = f'"{Z}-{element}-{A} for TENDL 2017"'
@@ -231,7 +355,10 @@ def fill_input_template(
         self_shielding_temp=temperature,
         final_broadr_temp=temperature,
         groupr_temp=temperature,
-        title=title,                                            
+        title=title,
+        ign=ign,
+        ngn=ngn,
+        egn=egn,                     
         reactions=card9,                                        
     )
 

--- a/tools/ALARAJOYWrapper/njoy_tools.py
+++ b/tools/ALARAJOYWrapper/njoy_tools.py
@@ -118,6 +118,42 @@ elements = [
 ]
 elements = dict(zip(elements, range(1, len(elements)+1)))
 
+NJOY_GROUPS = {
+    2  :          'CSWEG-239',
+    3  :            'LANL-30',
+    4  :             'ANL-27',
+    5  :             'RRD-50',
+    6  :           'GAM-I-68',
+    7  :         'GAM-II-100',
+    8  :   'LASER-THERMOS-35',
+    9  :        'EPRI-CPM-69',
+    10 :           'LANL-187',
+    11 :            'LANL-70',
+    12 :        'SAND-II-620',
+    13 :            'LANL-80',
+    14 :         'EURLIB-100',
+    15 :       'SAND-IIA-640',
+    16 :      'VITAMIN-E-174',
+    17 :      'VITAMIN-J-175',
+    18 :      'XMAS-NEA-LANL',
+    19 :            'ECCO-33',
+    20 :          'ECCO-1968',
+    21 :        'TRIPOLI-315',
+    22 :      'XMAS-LWPC-172',
+    23 : 'VITAMIN-J-LWPC-175',
+    24 :       'SHEM-CEA-281',
+    25 :       'SHEM-EPM-291',
+    26 :   'SHEM-CEA/EPM-361',
+    27 :       'SHEM-EPM-315',
+    28 :      'RAHAB-AECL-89',
+    29 :           'CCFE-660',
+    30 :         'UKAEA-1025',
+    31 :         'UKAEA-1067',
+    32 :         'UKAEA-1102',
+    33 :          'UKAEA-142',
+    34 :           'LANL-618'
+}
+
 def set_group_structure(group_struct_arg):
     """
     Interpret the group_structure argument (`-g`) to define the requisite NJOY
@@ -170,6 +206,7 @@ def set_group_structure(group_struct_arg):
         ngn (str): Number of groups. Will be an empty string unless ign == 1.
         egn (str): Space-joined string of all energy group bounds in
             ascending order. Will be an empty string unless ign == 1.
+        group_name (str): Name of the provided group structure.
     """
 
     ngn = ''
@@ -177,15 +214,17 @@ def set_group_structure(group_struct_arg):
 
     # Default to Vitamin-J group structure if none is provided from args
     if group_struct_arg is None:
-        ign = 17 # NJOY flag for Vitamin-J
+        ign = 17
+        group_name = 'VITAMIN-J-175'
 
     else:
         group_struct = group_struct_arg[0]
 
         # Check if provided group structure is among the list of built-in NJOY
         # group structures (ign values 2-34)
-        if group_struct in np.arange(2,35).astype(str):
+        if group_struct in np.array(list(NJOY_GROUPS)).astype(str):
             ign = group_struct
+            group_name = NJOY_GROUPS[int(group_struct)]
 
         # NJOY "arbitrary group structure" option
         else:
@@ -195,11 +234,13 @@ def set_group_structure(group_struct_arg):
             # into an array
             if Path(group_struct).is_file():
                 group_bounds = np.loadtxt(group_struct)
+                group_name = f'CUSTOM-{len(group_bounds)}'
 
             # If group structure name is provided, extract values from OpenMC
             else:
                 from openmc.mgxs import GROUP_STRUCTURES
-                group_bounds = GROUP_STRUCTURES.get(group_struct.upper(), [])
+                group_name = group_struct.upper()
+                group_bounds = GROUP_STRUCTURES.get(group_name, [])
 
             if len(group_bounds) == 0:
                 raise ValueError(
@@ -212,7 +253,7 @@ def set_group_structure(group_struct_arg):
             ngn = str(len(group_bounds) - 1)
             egn = ' '.join(np.array(sorted(group_bounds)).astype(str))
 
-    return ign, ngn, egn
+    return ign, ngn, egn, group_name
 
 def card9_special_isomer_reactions(pKZA, MT, mt_data, isomer_data, mtname):
     """

--- a/tools/ALARAJOYWrapper/njoy_tools.py
+++ b/tools/ALARAJOYWrapper/njoy_tools.py
@@ -164,9 +164,9 @@ def set_group_structure(group_struct_arg):
             Vitamin-J 175 group structure settings to be applied.
 
     Returns:
-        ign (str): GROUPR neutron group structure parameter. ign = 1 for
-            arbitrary group structures not contained in NJOY's built-in list
-            of options.
+        ign (str or int): GROUPR neutron group structure parameter. ign = 1
+            for arbitrary group structures not contained in NJOY's built-in
+            list of options.
         ngn (str): Number of groups. Will be an empty string unless ign == 1.
         egn (str): Space-joined string of all energy group bounds in
             ascending order. Will be an empty string unless ign == 1.

--- a/tools/ALARAJOYWrapper/njoy_tools.py
+++ b/tools/ALARAJOYWrapper/njoy_tools.py
@@ -231,8 +231,8 @@ def set_group_structure(group_struct_arg):
     else:
         ign = 1
         group_bounds = []
-        # If support file containing group bounds is provided, load them
-        # into an array
+        # If support file containing group bounds is provided, load them into
+        # an array
         if Path(group_struct).is_file():
             group_bounds = np.loadtxt(group_struct)
             group_name = 'user-provided ' + (
@@ -247,8 +247,8 @@ def set_group_structure(group_struct_arg):
 
         if len(group_bounds) == 0:
             raise ValueError(
-                'Invalid group structure provided. Must either be an '  \
-                'ign value known by NJOY, a group structure name in '   \
+                'Invalid group structure provided. Must either be an ign '  \
+                'value known by NJOY, a group structure name in '   \
                 '`openmc.mgxs.GROUP_STRUCTURES`, or a file containing ' \
                 'explicit energy group bounds.'
             )

--- a/tools/ALARAJOYWrapper/njoy_tools.py
+++ b/tools/ALARAJOYWrapper/njoy_tools.py
@@ -184,7 +184,7 @@ def set_group_structure(group_struct_arg):
 
         # Check if provided group structure is among the list of built-in NJOY
         # group structures (ign values 2-34)
-        if group_struct in range(2,35):
+        if group_struct in np.arange(2,35).astype(str):
             ign = group_struct
 
         # NJOY "arbitrary group structure" option

--- a/tools/ALARAJOYWrapper/preprocess_fendl3.py
+++ b/tools/ALARAJOYWrapper/preprocess_fendl3.py
@@ -53,10 +53,10 @@ def make_argparser():
         ''')
     )
     parser.add_argument(
-        '--group_structure', '-g', required=False, nargs=1,
+        '--group_structure', '-g', required=False, nargs=1, default=['17'],
         help=('''
             Specification for group structure in which to convert TENDL cross-
-                sections. See tendl_processing.set_group_structure() for
+                sections. See njoy_tools.set_group_structure() for
                 specific details for acceptable forms in which to supply this
                 argument.
         ''')

--- a/tools/ALARAJOYWrapper/preprocess_fendl3.py
+++ b/tools/ALARAJOYWrapper/preprocess_fendl3.py
@@ -407,7 +407,7 @@ def main():
         Path(args.fendlFileDir[0]) if args.fendlFileDir else dir
     )
     temperature = args.temperature[0]
-    ign, ngn, egn = njt.set_group_structure(args.group_structure)
+    ign, ngn, egn, group_name = njt.set_group_structure(args.group_structure)
 
     mt_dict = rxd.process_mt_data(rxd.load_mt_table(dir / 'mt_table.csv'))
     eaf_nucs = rxd.find_eaf_ref_data(Path(args.decay_lib[0]))
@@ -455,6 +455,10 @@ def main():
 
     dsv_path = dir / 'cumulative_gendf_data.dsv'
     write_dsv(dsv_path, gas_filtered, nGroups)
+    print(
+        f'Neutron activation cross-sections converted to {nGroups} groups ' \
+        f'according to the {group_name} group structure.'
+    )
     print(f'Reaction data saved to: {dsv_path}')
 
 if __name__ == '__main__':

--- a/tools/ALARAJOYWrapper/preprocess_fendl3.py
+++ b/tools/ALARAJOYWrapper/preprocess_fendl3.py
@@ -56,9 +56,8 @@ def make_argparser():
         '--group_structure', '-g', required=False, nargs=1, default=['17'],
         help=('''
             Specification for group structure in which to convert TENDL cross-
-                sections. See njoy_tools.set_group_structure() for
-                specific details for acceptable forms in which to supply this
-                argument.
+                sections. See njoy_tools.set_group_structure() for specific
+                details for acceptable forms in which to supply this argument.
         ''')
     )
     return parser

--- a/tools/ALARAJOYWrapper/preprocess_fendl3.py
+++ b/tools/ALARAJOYWrapper/preprocess_fendl3.py
@@ -9,7 +9,7 @@ import logging
 from pathlib import Path
 from collections import defaultdict
 
-def args():
+def make_argparser():
     parser = argparse.ArgumentParser()
     parser.add_argument(
         '--decay_lib', '-d', required=True, nargs=1,
@@ -52,7 +52,16 @@ def args():
                 arise to a log file.
         ''')
     )
-    return parser.parse_args()
+    parser.add_argument(
+        '--group_structure', '-g', required=False, nargs=1,
+        help=('''
+            Specification for group structure in which to convert TENDL cross-
+                sections. See tendl_processing.set_group_structure() for
+                specific details for acceptable forms in which to supply this
+                argument.
+        ''')
+    )
+    return parser
 
 def configure_logging(redirect_warnings=False):
     """
@@ -146,8 +155,8 @@ def process_pendf(
     return MTs, isomer_dict, njoy_error
 
 def process_gendf(
-    njoy_groupr_input, material_id, MTs, mt_dict,
-    temperature, pKZA, isomer_dict, all_rxns, eaf_nucs
+    njoy_groupr_input, material_id, MTs, mt_dict, temperature, pKZA,
+    isomer_dict, all_rxns, eaf_nucs, ign=17, ngn='', egn=''
 ):
     """
     Prepare and run NJOY run with GROUPR and iteratively extract cross-section
@@ -184,6 +193,17 @@ def process_gendf(
             }
         eaf_nucs (dict): Dictionary keyed by all radionuclides in the EAF
             decay library, with values of their half-lives.
+        ign (str or int, optional): GROUPR neutron group structure parameter.
+            ign = 1 for arbitrary group structures not contained in NJOY's
+            built-in list of options. Default value corresponds to ign key for
+            the Vitamin-J 175 energy group structure.
+            (Defaults to 17)
+        ngn (str, optional): Number of groups. Will be an empty string unless
+            ign == 1.
+            (Defaults to '')
+        egn (str): Space-joined string of all energy group bounds in ascending
+            order. Will be an empty string unless ign == 1.
+            (Defaults to '')
 
     Returns:
         all_rxns (collections.defaultdict): Updated dictionary for all
@@ -193,7 +213,8 @@ def process_gendf(
     element, A = tp.interpret_KZA(pKZA)
     groupr_input = njt.fill_input_template(
         njoy_groupr_input, material_id, MTs, element,
-        A, mt_dict, temperature, pKZA, isomer_dict
+        A, mt_dict, temperature, pKZA, isomer_dict,
+        ign=ign, ngn=ngn, egn=egn
     )
     njt.write_njoy_input_file(groupr_input)
     gendf_path, njoy_error = njt.run_njoy(
@@ -203,7 +224,7 @@ def process_gendf(
     if gendf_path:
         # Extract MT values again from GENDF file as there may be some
         # difference from the original MT values in the ENDF/PENDF files
-        xs_line_dict, gendf_MTs = tp.extract_gendf_data(gendf_path)
+        xs_line_dict, gendf_MTs, nGroups = tp.extract_gendf_data(gendf_path)
         if MTs != gendf_MTs:
             diffs = sorted(MTs - gendf_MTs)
             warnings.warn(
@@ -213,7 +234,7 @@ def process_gendf(
         if gendf_MTs:
             all_rxns = tp.iterate_MTs(
                 gendf_MTs, mt_dict, xs_line_dict, pKZA, 
-                all_rxns, eaf_nucs, isomer_dict, gendf_path
+                all_rxns, eaf_nucs, isomer_dict, nGroups
             )
             print(f'Finished processing {element}-{A}')
 
@@ -231,7 +252,7 @@ def process_gendf(
             NJOY error message: {njoy_error}'''
         )
 
-    return all_rxns
+    return all_rxns, nGroups
 
 def subtract_gas_from_totals(all_rxns):
     """
@@ -274,7 +295,7 @@ def subtract_gas_from_totals(all_rxns):
 
     return all_rxns
 
-def combine_daughter_pathways(gas_filtered):
+def combine_daughter_pathways(gas_filtered, nGroups):
     """
     Calculate cumulative cross-sections from all reaction pathways that
         produce like daughters.
@@ -293,8 +314,8 @@ def combine_daughter_pathways(gas_filtered):
     for parent in gas_filtered:
         for daughter, rxn_list in gas_filtered[parent].items():
             collapsed = {
-                'emitted'    :                                 set(),
-                'xsections'  :  np.zeros(tp.VITAMIN_J_ENERGY_GROUPS)
+                'emitted'    :  set(),
+                'xsections'  :  np.zeros(nGroups)
             }
 
             for rxn in rxn_list.values():
@@ -325,7 +346,7 @@ def rxn_to_str(parent, daughter, rxn):
 
     return dsv_row
 
-def write_dsv(dsv_path, all_rxns):
+def write_dsv(dsv_path, all_rxns, nGroups):
     """
     Write out a space-delimited DSV file from the list of dictionaries,
         dsv_path, produced by iterating through each reaction of each isotope
@@ -355,7 +376,7 @@ def write_dsv(dsv_path, all_rxns):
     """
 
     with open(dsv_path, 'w') as dsv:
-        dsv.write(str(tp.VITAMIN_J_ENERGY_GROUPS) + '\n')
+        dsv.write(str(nGroups) + '\n')
         for parent in sorted(all_rxns):
             for daughter in all_rxns[parent]:
                 if parent != daughter:
@@ -370,22 +391,26 @@ def main():
     Main method when run as a command line script.
     """
 
+    argparser = make_argparser()
+    args = argparser.parse_args()
+
     warnings.formatwarning = (
         lambda msg, cat, fname, lineno, file=None, line=None:
             f"{Path(fname).name}:{lineno}: {cat.__name__}: {msg}\n"
     )
-    configure_logging(args().redirect_warnings)
+    configure_logging(args.redirect_warnings)
 
     TAPE20 = Path('tape20')
 
     dir = njt.set_directory()
     search_dir = (
-        Path(args().fendlFileDir[0]) if args().fendlFileDir else dir
-        )
-    temperature = args().temperature[0]
+        Path(args.fendlFileDir[0]) if args.fendlFileDir else dir
+    )
+    temperature = args.temperature[0]
+    ign, ngn, egn = njt.set_group_structure(args.group_structure)
 
     mt_dict = rxd.process_mt_data(rxd.load_mt_table(dir / 'mt_table.csv'))
-    eaf_nucs = rxd.find_eaf_ref_data(Path(args().decay_lib[0]))
+    eaf_nucs = rxd.find_eaf_ref_data(Path(args.decay_lib[0]))
     all_rxns = defaultdict(lambda: defaultdict(dict))
 
     for file_properties in tp.search_for_files(search_dir):
@@ -408,9 +433,10 @@ def main():
         )
 
         if not njoy_prep_error:
-            all_rxns = process_gendf(
+            all_rxns, nGroups = process_gendf(
                 njt.groupr_input, material_id, MTs, mt_dict,
-                temperature, pKZA, isomer_dict, all_rxns, eaf_nucs 
+                temperature, pKZA, isomer_dict, all_rxns, eaf_nucs,
+                ign=ign, ngn=ngn, egn=egn
             )
 
         else:
@@ -424,11 +450,11 @@ def main():
     # Handle gas total production cross-sections, per user specifications
     gas_filtered = subtract_gas_from_totals(all_rxns)
 
-    if args().amalgamate:
-        gas_filtered = combine_daughter_pathways(gas_filtered)
+    if args.amalgamate:
+        gas_filtered = combine_daughter_pathways(gas_filtered, nGroups)
 
     dsv_path = dir / 'cumulative_gendf_data.dsv'
-    write_dsv(dsv_path, gas_filtered)
+    write_dsv(dsv_path, gas_filtered, nGroups)
     print(f'Reaction data saved to: {dsv_path}')
 
 if __name__ == '__main__':

--- a/tools/ALARAJOYWrapper/preprocess_fendl3.py
+++ b/tools/ALARAJOYWrapper/preprocess_fendl3.py
@@ -223,7 +223,10 @@ def process_gendf(
     if gendf_path:
         # Extract MT values again from GENDF file as there may be some
         # difference from the original MT values in the ENDF/PENDF files
-        xs_line_dict, gendf_MTs, nGroups = tp.extract_gendf_data(gendf_path)
+        non_zero_xs, gendf_MTs, nGroups = tp.extract_gendf_data(
+            gendf_path, material_id
+        )
+
         if MTs != gendf_MTs:
             diffs = sorted(MTs - gendf_MTs)
             warnings.warn(
@@ -232,7 +235,7 @@ def process_gendf(
             )
         if gendf_MTs:
             all_rxns = tp.iterate_MTs(
-                gendf_MTs, mt_dict, xs_line_dict, pKZA, 
+                gendf_MTs, mt_dict, non_zero_xs, pKZA, 
                 all_rxns, eaf_nucs, isomer_dict, nGroups
             )
             print(f'Finished processing {element}-{A}')
@@ -444,7 +447,7 @@ def main():
                 NJOY error message: {njoy_prep_error}'''
             )
 
-        njt.cleanup_njoy_files(element, A)
+        #njt.cleanup_njoy_files(element, A)
 
     # Handle gas total production cross-sections, per user specifications
     gas_filtered = subtract_gas_from_totals(all_rxns)

--- a/tools/ALARAJOYWrapper/preprocess_fendl3.py
+++ b/tools/ALARAJOYWrapper/preprocess_fendl3.py
@@ -447,7 +447,7 @@ def main():
                 NJOY error message: {njoy_prep_error}'''
             )
 
-        #njt.cleanup_njoy_files(element, A)
+        njt.cleanup_njoy_files(element, A)
 
     # Handle gas total production cross-sections, per user specifications
     gas_filtered = subtract_gas_from_totals(all_rxns)

--- a/tools/ALARAJOYWrapper/preprocess_fendl3.py
+++ b/tools/ALARAJOYWrapper/preprocess_fendl3.py
@@ -2,6 +2,7 @@
 import reaction_data as rxd
 import tendl_processing as tp
 import njoy_tools as njt
+import xs_plotting as xp
 import numpy as np
 import argparse
 import warnings
@@ -58,6 +59,14 @@ def make_argparser():
             Specification for group structure in which to convert TENDL cross-
                 sections. See njoy_tools.set_group_structure() for specific
                 details for acceptable forms in which to supply this argument.
+        ''')
+    )
+    parser.add_argument(
+        '--xs_plotting', '-p', action='store_true',
+        help=('''
+            Optional argument to comparatively plot all converted groupwise
+                neutron cross-sections over the continuous energy cross-
+                sections from the original TENDL file.
         ''')
     )
     return parser
@@ -327,13 +336,14 @@ def combine_daughter_pathways(gas_filtered, nGroups):
 
     return gas_filtered
 
-def rxn_to_str(parent, daughter, rxn):
+def rxn_to_str(parent, daughter, MT, rxn):
     """
     Generate the list of strings to be written in a single row of the DSV file.
 
     Arguments:
         parent (int): KZA of the reaction's parent nuclide.
         daughter (int): KZA of the reaction's daughter nuclide.
+        MT (int): Reaction identifying number.
         rxn (dict): Dictionary for the given reaction containing cross-section
             and emitted particle data.
 
@@ -341,12 +351,11 @@ def rxn_to_str(parent, daughter, rxn):
         dsv_row (str): Joined string of all row data for a single reaction.
     """
 
-    dsv_row = f'{parent} {daughter} {rxn['emitted']} '
-    dsv_row += ' '.join(str(xs) for xs in rxn['xsections'])
+    dsv_row = f'{parent} {daughter} {MT} {rxn['emitted']} '
 
-    return dsv_row
+    return dsv_row + ' '.join(str(xs) for xs in rxn['xsections'])
 
-def write_dsv(dsv_path, all_rxns, nGroups):
+def write_dsv(dsv_path, all_rxns, nGroups, group_name):
     """
     Write out a space-delimited DSV file from the list of dictionaries,
         dsv_path, produced by iterating through each reaction of each isotope
@@ -370,19 +379,23 @@ def write_dsv(dsv_path, all_rxns, nGroups):
                     }
                 }    
             }
+        group_name (str): Name of the group structure into which cross-
+            sections were converted.
 
     Returns:
         None 
     """
 
     with open(dsv_path, 'w') as dsv:
-        dsv.write(str(nGroups) + '\n')
+        dsv.write(f'{nGroups} {group_name}\n')
         for parent in sorted(all_rxns):
             for daughter in all_rxns[parent]:
                 if parent != daughter:
-                    for rxn in all_rxns[parent][daughter].values():
+                    for MT, rxn in all_rxns[parent][daughter].items():
                         if rxn['xsections'].sum() > 0:
-                            dsv.write(f'{rxn_to_str(parent,daughter,rxn)}\n')
+                            dsv.write(
+                                f'{rxn_to_str(parent, daughter, MT, rxn)}\n'
+                            )
         # End of File (EOF) signifier to be read by ALARAJOY
         dsv.write(str(-1))
 
@@ -454,12 +467,18 @@ def main():
         gas_filtered = combine_daughter_pathways(gas_filtered, nGroups)
 
     dsv_path = dir / 'cumulative_gendf_data.dsv'
-    write_dsv(dsv_path, gas_filtered, nGroups)
+    write_dsv(dsv_path, gas_filtered, nGroups, group_name)
+
     print(
         f'Neutron activation cross-sections converted to {nGroups} groups ' \
         f'according to the {group_name} group structure.'
     )
     print(f'Reaction data saved to: {dsv_path}')
+
+    if args.xs_plotting:
+        xp.plot_cross_sections(xp.all_rxns_to_plotting_dict(
+            gas_filtered, search_dir
+        ))
 
 if __name__ == '__main__':
     main()

--- a/tools/ALARAJOYWrapper/preprocess_fendl3.py
+++ b/tools/ALARAJOYWrapper/preprocess_fendl3.py
@@ -223,9 +223,7 @@ def process_gendf(
     if gendf_path:
         # Extract MT values again from GENDF file as there may be some
         # difference from the original MT values in the ENDF/PENDF files
-        non_zero_xs, gendf_MTs, nGroups = tp.extract_gendf_data(
-            gendf_path, material_id
-        )
+        non_zero_xs, gendf_MTs, nGroups = tp.extract_gendf_data(gendf_path)
 
         if MTs != gendf_MTs:
             diffs = sorted(MTs - gendf_MTs)

--- a/tools/ALARAJOYWrapper/tendl_processing.py
+++ b/tools/ALARAJOYWrapper/tendl_processing.py
@@ -7,7 +7,6 @@ from collections import defaultdict
 import warnings
 import numpy as np
 
-VITAMIN_J_ENERGY_GROUPS = 175
 EXCITATION_DICT = {
     4   : np.arange(51 ,  92), # (n,n*)  reactions
     103 : np.arange(600, 650), # (n,p*)  reactions
@@ -285,6 +284,8 @@ def extract_gendf_data(gendf_path):
             the parsed GENDF file containing cross-section data.
          MTs (set of ints): All reaction types with cross-section data in the
             provided GENDF.
+        nGroups (int): Number of energy groups into which the groupwise cross
+            sections were calculated.
     """
 
     MTs = set()
@@ -292,10 +293,17 @@ def extract_gendf_data(gendf_path):
     current_section_lines = []
     current_MT = None
     line_count = 0
+    nGroups = None
 
     with open(gendf_path, 'r') as f:
         for line in f:
             mf, mt = _gendf_parse_control(line)
+            
+            # Extract number of groups, found in second line of file
+            # description section
+            if mf == 1 and mt == 451 and int(line.rstrip('\n')[-3:]) == 2:
+               nGroups = int(line.split()[2])
+
             if mf == 3 and mt != 0:
                 MTs.add(mt)
                 if mt != current_MT:
@@ -317,9 +325,15 @@ def extract_gendf_data(gendf_path):
                 current_MT = None
                 line_count = 0
 
-    return xs_line_dict, MTs
+    if nGroups is None:
+        raise ValueError(
+            f'{gendf_path} misformatted. Expecting to find group number in ' \
+            'MF1, MT451.'
+        )
 
-def process_xsections(xs_lines, M_values):
+    return xs_line_dict, MTs, nGroups
+
+def process_xsections(xs_lines, M_values, nGroups):
     """
     Given a list of lines containing all cross-section data for a given
         reaction type, identify all excitation pathways and save reformatted
@@ -333,11 +347,14 @@ def process_xsections(xs_lines, M_values):
             cross-section data.
         M_values (list of int): All possible isomeric states of the residual
             daughter produced from the given reaction type.
+        nGroups (int): Number of energy groups into which the groupwise cross
+            sections were calculated.
     
     Returns:
         sigma_dict (dict): Dictionary keyed by excitation levels (M) with
             values of padded NumPy arrays containing groupwise cross-sections
-            following the VITAMIN-J group structure.
+            following the group structure provided by the user or the default
+            Vitamin-J 175 group structure if none is otherwise specified.
     """
 
     sigma_dict = {}
@@ -353,9 +370,7 @@ def process_xsections(xs_lines, M_values):
             float(line.split(' ')[2].replace('+','E+').replace('-','E-'))
             for line in lines
         ][::-1]
-        sigma_dict[M] = np.pad(
-            sigmas, (0, VITAMIN_J_ENERGY_GROUPS - len(sigmas))
-        )
+        sigma_dict[M] = np.pad(sigmas, (0, nGroups - len(sigmas)))
     
     return sigma_dict
 
@@ -384,7 +399,7 @@ def incrementally_deexcite_isomer(M, dKZA, eaf_nucs):
     return dKZA + trial_M
 
 def iterate_MTs(
-    MTs, mt_dict, xs_line_dict, pKZA, all_rxns, eaf_nucs, isomer_dict, gendf_path
+    MTs, mt_dict, xs_line_dict, pKZA, all_rxns, eaf_nucs, isomer_dict, nGroups
 ):
     """
     Iterate through all of the MTs present in a given GENDF file to extract
@@ -423,8 +438,8 @@ def iterate_MTs(
             level has a list of all isomeric states of possible daughter
             nuclides for which there are cross-section data in the original
             TENDL file.
-        gendf_path (pathlib._local.PosixPath): Path to the GENDF file from
-            which to extract groupwise cross-sections.
+        nGroups (int): Number of energy groups into which the groupwise cross
+            sections were calculated.
             
     Returns:
         all_rxns (collections.defaultdict): Updated dictionary for all
@@ -440,7 +455,7 @@ def iterate_MTs(
     for MT in filtered_MTs:
         xs_lines = xs_line_dict[MT]
         M_values = list(isomer_dict[MT].values())[0]
-        isomer_specific_rxns = process_xsections(xs_lines, M_values)
+        isomer_specific_rxns = process_xsections(xs_lines, M_values, nGroups)
         rxn = mt_dict[MT]
         gas = rxn['gas']
         
@@ -481,13 +496,11 @@ def iterate_MTs(
                 if special_MT not in all_rxns[pKZA][dKZA]:
                     all_rxns[pKZA][dKZA][special_MT] = {
                         'emitted'  : emitted,
-                        'xsections': np.zeros(VITAMIN_J_ENERGY_GROUPS)
+                        'xsections': np.zeros(nGroups)
                     }
 
                 all_rxns[pKZA][dKZA][special_MT][
                     'xsections'
-                ] += np.pad(
-                    sigmas, (0, VITAMIN_J_ENERGY_GROUPS - len(sigmas))
-                )
+                ] += np.pad(sigmas, (0, nGroups - len(sigmas)))
 
     return all_rxns

--- a/tools/ALARAJOYWrapper/tendl_processing.py
+++ b/tools/ALARAJOYWrapper/tendl_processing.py
@@ -268,7 +268,7 @@ def _gendf_parse_control(line):
     except ValueError:
         return None, None
 
-def extract_gendf_data(gendf_path, material_id):
+def extract_gendf_data(gendf_path):
     """
     Parse a GENDF-formatted (post-GROUPR processing) file for lines containing
         cross-section data for each reaction type, while compiling a full set
@@ -277,8 +277,6 @@ def extract_gendf_data(gendf_path, material_id):
     Arguments
         gendf_path (pathlib._local.PosixPath): Path to the GENDF file from
              which to extract cross-section data.
-        material_id (int): Unique material ID of the parent nuclide catalogued
-            in the GENDF file.
 
     Returns:
         non_zero_xs (collections.defaultdict): Dictionary keyed by MT number
@@ -325,20 +323,18 @@ def extract_gendf_data(gendf_path, material_id):
                     continue
 
                 if line_count % 2 == 0:
-                    current_IG = int(
-                        line[:line.index(str(material_id))].split()[-1]
-                    )
+                    current_IG = int(line[62:66])
 
                 else:
                     current_section[current_IG] = float(
-                        line.split()[2].replace('+','E+').replace('-','E-')
+                        line.split()[1].replace('+','E+').replace('-','E-')
                     )
-            
+
             else:
                 if current_section:
                     non_zero_xs[current_MT].append(current_section)
                     current_section = {}
-                
+
                 current_MT = None
                 current_IG = None
                 line_count = 0

--- a/tools/ALARAJOYWrapper/tendl_processing.py
+++ b/tools/ALARAJOYWrapper/tendl_processing.py
@@ -268,20 +268,23 @@ def _gendf_parse_control(line):
     except ValueError:
         return None, None
 
-def extract_gendf_data(gendf_path):
+def extract_gendf_data(gendf_path, material_id):
     """
     Parse a GENDF-formatted (post-GROUPR processing) file for lines containing
         cross-section data for each reaction type, while compiling a full set
         of all MT numbers corresponding to that reaction.
 
     Arguments
-         gendf_path (pathlib._local.PosixPath): Path to the GENDF file from
+        gendf_path (pathlib._local.PosixPath): Path to the GENDF file from
              which to extract cross-section data.
+        material_id (int): Unique material ID of the parent nuclide catalogued
+            in the GENDF file.
 
     Returns:
-        xs_line_dict (collections.defaultdict): Dictionary keyed by MT number
-            with values of lists of all line strings in the MT-section from
-            the parsed GENDF file containing cross-section data.
+        non_zero_xs (collections.defaultdict): Dictionary keyed by MT number
+            valued by lists of sub-dictionaries. Each of these are keyed by
+                the GROUPR group index tag (`IG`) and valued by the associated
+                groupwise cross-section value for that energy group.
          MTs (set of ints): All reaction types with cross-section data in the
             provided GENDF.
         nGroups (int): Number of energy groups into which the groupwise cross
@@ -289,9 +292,11 @@ def extract_gendf_data(gendf_path):
     """
 
     MTs = set()
-    xs_line_dict = defaultdict(list)
-    current_section_lines = []
+    non_zero_xs = defaultdict(list)
+
     current_MT = None
+    current_section = {}
+    current_IG = None
     line_count = 0
     nGroups = None
 
@@ -307,22 +312,35 @@ def extract_gendf_data(gendf_path):
             if mf == 3 and mt != 0:
                 MTs.add(mt)
                 if mt != current_MT:
-                    if current_section_lines:
-                        xs_line_dict[current_MT].append(current_section_lines)
-                        current_section_lines = []
+                    if current_section:
+                        non_zero_xs[current_MT].append(current_section)
+                    
+                    current_section = {}
                     current_MT = mt
                     line_count = 0
 
                 line_count += 1
 
-                if line_count >= 3 and line_count % 2 == 1:
-                    current_section_lines.append(line)
+                if line_count < 2:
+                    continue
 
+                if line_count % 2 == 0:
+                    current_IG = int(
+                        line[:line.index(str(material_id))].split()[-1]
+                    )
+
+                else:
+                    current_section[current_IG] = float(
+                        line.split()[2].replace('+','E+').replace('-','E-')
+                    )
+            
             else:
-                if current_section_lines:
-                    xs_line_dict[current_MT].append(current_section_lines)
-                    current_section_lines = []
+                if current_section:
+                    non_zero_xs[current_MT].append(current_section)
+                    current_section = {}
+                
                 current_MT = None
+                current_IG = None
                 line_count = 0
 
     if nGroups is None:
@@ -331,20 +349,21 @@ def extract_gendf_data(gendf_path):
             'MF1, MT451.'
         )
 
-    return xs_line_dict, MTs, nGroups
+    return non_zero_xs, MTs, nGroups
 
-def process_xsections(xs_lines, M_values, nGroups):
+def populate_xs(xs_by_index, M_values, nGroups):
     """
-    Given a list of lines containing all cross-section data for a given
-        reaction type, identify all excitation pathways and save reformatted
-        and padded cross-section arrays to a dictionary keyed by isomeric
-        states (M). Each reaction type may have multiple actual reaction
-        pathways, corresponding to different isomeric states of the daughter,
-        which appear within the file in ascending order of excitation.
+    Given a dictionary containing all cross-section data for a given reaction
+        type, identify all excitation pathways and save group-positioned 
+        cross-section arrays to a dictionary keyed by isomeric states (M).
+        Each reaction type may have multiple actual reaction pathways,
+        corresponding to different isomeric states of the daughter, which
+        appear within the file in ascending order of excitation.
     
     Arguments:
-        xs_lines (line of str): List of all lines in the MT-section containing
-            cross-section data.
+        xs_by_index (dict): Dictionary of all non-zero cross-sections for a
+            given MT value keyed by the GROUPR group index tag (`IG`) and
+            valued by the groupwise cross-section in barns.
         M_values (list of int): All possible isomeric states of the residual
             daughter produced from the given reaction type.
         nGroups (int): Number of energy groups into which the groupwise cross
@@ -359,19 +378,19 @@ def process_xsections(xs_lines, M_values, nGroups):
 
     sigma_dict = {}
     excitations = len(M_values)
-    N = min(excitations, len(xs_lines))
-    
-    # If multiple excitations, M values equal the list indices of LFS values
+    N = min(excitations, len(xs_by_index))
+
     if excitations > 1:
         M_values = list(range(excitations))
 
-    for M, lines in zip(M_values[:N], xs_lines[:N]):
-        sigmas = [
-            float(line.split(' ')[2].replace('+','E+').replace('-','E-'))
-            for line in lines
-        ][::-1]
-        sigma_dict[M] = np.pad(sigmas, (0, nGroups - len(sigmas)))
-    
+    for M, ordered_xs in zip(M_values[:N], xs_by_index[:N]):
+        sigmas = np.zeros(nGroups)
+
+        for IG, sigma in ordered_xs.items():
+            sigmas[IG - 1] = sigma
+
+        sigma_dict[M] = sigmas[::-1]
+
     return sigma_dict
 
 def incrementally_deexcite_isomer(M, dKZA, eaf_nucs):
@@ -399,7 +418,7 @@ def incrementally_deexcite_isomer(M, dKZA, eaf_nucs):
     return dKZA + trial_M
 
 def iterate_MTs(
-    MTs, mt_dict, xs_line_dict, pKZA, all_rxns, eaf_nucs, isomer_dict, nGroups
+    MTs, mt_dict, non_zero_xs, pKZA, all_rxns, eaf_nucs, isomer_dict, nGroups
 ):
     """
     Iterate through all of the MTs present in a given GENDF file to extract
@@ -414,9 +433,11 @@ def iterate_MTs(
     
     Arguments:
         MTs (list of int): List of reaction types present in the GENDF file.
-        file_obj (ENDFtk.tree.File): ENDFtk file object containing the
-            contents for a specific material's cross-section data.
         mt_dict (dict): Dictionary formatted data structure for mt_table.csv
+        non_zero_xs (collections.defaultdict): Dictionary keyed by MT number
+            valued by lists of sub-dictionaries. Each of these are keyed by
+                the GROUPR group index tag (`IG`) and valued by the associated
+                groupwise cross-section value for that energy group.        
         pKZA (int): Parent KZA identifier.
         all_rxns (collections.defaultdict): Hierarchical dictionary keyed by
             parent nuclides to store all reaction data, with structured as:
@@ -453,14 +474,13 @@ def iterate_MTs(
             filtered_MTs.add(MT)
 
     for MT in filtered_MTs:
-        xs_lines = xs_line_dict[MT]
+        xs_by_index = non_zero_xs[MT]
         M_values = list(isomer_dict[MT].values())[0]
-        isomer_specific_rxns = process_xsections(xs_lines, M_values, nGroups)
         rxn = mt_dict[MT]
         gas = rxn['gas']
         
         # Calculate dKZA values for each excitation pathway in MF10
-        for M, sigmas in isomer_specific_rxns.items():
+        for M, sigmas in populate_xs(xs_by_index, M_values, nGroups).items():
             emitted = rxn['emitted']
             dKZA = (((pKZA // 10) * 10 + rxn['delKZA']) // 10) * 10 + M
             if gas:
@@ -499,8 +519,6 @@ def iterate_MTs(
                         'xsections': np.zeros(nGroups)
                     }
 
-                all_rxns[pKZA][dKZA][special_MT][
-                    'xsections'
-                ] += np.pad(sigmas, (0, nGroups - len(sigmas)))
+                all_rxns[pKZA][dKZA][special_MT]['xsections'] += sigmas
 
     return all_rxns

--- a/tools/ALARAJOYWrapper/xs_plotting.py
+++ b/tools/ALARAJOYWrapper/xs_plotting.py
@@ -260,7 +260,7 @@ def plot_cross_sections(plotting_dict):
 
                     if xs.size > 0:
                         stair_plot = ax.stairs(
-                            xs, energy_bounds[::-1], label=group_name
+                            xs[::-1], energy_bounds, label=group_name
                         )
                 
                 if stair_plot:

--- a/tools/ALARAJOYWrapper/xs_plotting.py
+++ b/tools/ALARAJOYWrapper/xs_plotting.py
@@ -240,9 +240,9 @@ def plot_cross_sections(plotting_dict):
                     # openmc.mgxs.GROUP_STRUCTURES, a reference file must
                     # exist in the CWD with a matching name to the group_name
                     # containing the group bounds explicitly
-                    energy_bounds = GROUP_STRUCTURES.get(
-                        group_name, sorted(np.loadtxt(group_name))
-                    )
+                    energy_bounds = GROUP_STRUCTURES.get(group_name, [])
+                    if len(energy_bounds) == 0:
+                        energy_bounds = sorted(np.loadtxt(group_name))
 
                     xs = np.array([])
                     for line in dsv_lines[1:-1]:

--- a/tools/ALARAJOYWrapper/xs_plotting.py
+++ b/tools/ALARAJOYWrapper/xs_plotting.py
@@ -1,0 +1,325 @@
+import matplotlib.pyplot as plt
+import numpy as np
+import argparse
+from openmc.mgxs import GROUP_STRUCTURES
+import njoy_tools as njt
+import tendl_processing as tp
+from collections import defaultdict
+from pathlib import Path
+from pathlib._local import PosixPath 
+import reaction_data as rxd
+
+def check_all_tag(param):
+    """
+    For a given plotting parameter (mass number or reaction), identify if the
+        stored value is `'all'`, as read in from the input `.yaml` file.
+
+    Arguments:
+        param (str or list): Object containing all values for either the mass
+            number or reaction parameter. If multiple values are present, then
+            `param` will necessarily be a list, otherwise it can be a string.
+
+    Returns:
+        is_all_tag (bool): Boolean descriptor of whether the given parameter
+            corresponds to `'all'` being selected.
+    """
+
+    return (
+        len(param) == 1
+        and isinstance(param[0], str)
+        and param[0].lower() == 'all'
+    )
+
+def flagged_num_to_int(num):
+    """
+    Convert numerical values that may be in string form containing additional
+        tags (i.e. '26m' or '4*') left over from groupwise processing to their
+        base integer form.
+
+    num (int or str): Numerical value, which may be in string form with
+        additional tags such as 'm' or '*'.
+
+    num_int (int): Numerical value stripped of any non-numerical characters in
+        integer form.
+    """
+
+    return int(''.join(char for char in str(num) if char.isdigit()))
+
+def extract_continuous_data(tendl_path, MT):
+    """
+    For a given nuclide and reaction, extract its continuous-energy cross-
+        sections and corresponding energies from its original TENDL file.
+
+    Arguments:
+        tendl_path (pathlib._local.PosixPath): Path to the nuclide's original
+            TENDL file.
+        MT (int): Reaction identifying number.
+
+    Returns:
+        tendl_xs (list): Continuous-energy cross-sections for a given
+            nuclide-reaction combination from the original TENDL file. If the
+            provided reaction type does not exist in the TENDL file (such as
+            gas production totals, which are calculated by the data
+            preprocessor), then tendl_xs will be empty.
+        tendl_energies (list): Corresponding energies for the cross-sections
+            for a given nuclide-reaction combination from the original TENDL
+            file. If the provided reaction type does not exist in the TENDL
+            file), then tendl_energies will be empty.
+    """
+    
+    tendl_xs = []
+    tendl_energies = []
+
+    file, _ = tp.create_endf_file_obj(tendl_path, 3)
+    MT = flagged_num_to_int(MT)
+    if MT in [MT.MT for MT in file.sections]:
+        section = file.section(MT).parse()
+        tendl_xs = list(section.cross_sections)
+        tendl_energies = list(section.energies)
+
+    return tendl_xs, tendl_energies
+
+def all_rxns_to_plotting_dict(all_rxns, tendl_dir):
+    """
+    Method to be called specifically within preprocess_fendl3.py to adapt the
+        all_rxns dictionary structure to the element -> nuclide -> reaction
+        hiearchical structure used by xs_plotting.py to produce and save
+        cross-section plots.
+
+    Arguments:
+        all_rxns (collections.defaultdict): Hierarchical dictionary keyed by
+            parent nuclides to store all reaction data, with structured as:
+            {parent:
+                {daughter:
+                    {MT:
+                        {
+                            'emitted': (str of emitted particles)
+                            'xsections': (array of groupwise XS)
+                        }
+                    }
+                }    
+            }
+        tendl_path (pathlib._local.PosixPath): Path to the directory in which
+            the TENDL data for the processing run is stored.
+
+    Returns:
+        plotting_dict (collections.defaultdict): Hiearchical dictionary keyed
+            by element with a sub-dictionary of mass-number as the keys, and
+            a set of reaction types (MTs) as the values. Additionally, at the
+            highest level of keys, a special key "TENDL" has a value for the
+            path to tendl_dir.
+    """
+
+    plotting_dict = defaultdict(lambda: defaultdict(set))
+    plotting_dict['TENDL'] = tendl_dir
+
+    for parent in all_rxns:
+        element, A = tp.interpret_KZA(parent)
+        for rxn in all_rxns[parent].values():
+            MT = list(rxn.keys())[0]      
+            plotting_dict[element][A].add(MT)
+
+    return plotting_dict
+
+def del_if_empty(directory):
+    """
+    Delete a directory if it does not contain any files within.
+
+    Arguments:
+        directory (pathlib._local.PosixPath): Path to a directory.
+
+    Returns:
+        None
+    """
+
+    if not any(directory.iterdir()):
+        directory.rmdir()    
+
+def plot_cross_sections(plotting_dict):
+    """
+    Plot the cross-sections for a collection of nuclides, reactions, and
+        groupwise DSVs comparatively to the continuous-energy TENDL cross-
+        sections. Groupwise cross-sections are plotted using the plt.stairs()
+        function, bounded by the particular energy group structure in which
+        the cross-section values weree produced. Plots are saved in a
+        hiearchical directory strcture by the following form:
+            TENDL_DATA_SOURCE
+                |-> ELEMENT
+                    |-> NUCLIDE
+                        |-> REACTION_1
+                        |-> ...
+                        |-> REACTION_N
+
+    Arguments:
+        plotting_dict (collections.defaultdict or dict): Hiearchical
+            dictionary keyed by element with a sub-dictionary of mass-number
+            as the keys, and a set of reaction types (MTs) as the values.
+            Additionally, at the highest level of keys, there are two special
+            subdictionaries of the form:
+                {
+                    'TENDL' : /path/to/tendl_data/ ,
+                    'DSV'   : list of all groupwise DSV data files
+                }
+
+        Returns:
+            None
+    """
+
+    plt.rcParams.update({'figure.max_open_warning': 0})
+
+    data_sets = plotting_dict.get('DSV', 'cumulative_gendf_data.dsv')
+    if not isinstance(data_sets, list):
+        data_sets = [data_sets]
+    
+    tendl_dir = plotting_dict.get('TENDL', Path('tendl2017'))
+    if not isinstance(tendl_dir, PosixPath):
+        tendl_dir = Path(tendl_dir)
+
+    top_dir = Path(f'{tendl_dir}_plots')
+    top_dir.mkdir(exist_ok=True)
+
+    elements = (
+        set(njt.elements) if 'all' in [key.lower() for key in plotting_dict]
+        else set(plotting_dict) & set(njt.elements)
+    )
+
+    for element in elements:
+        element_dir = top_dir / element
+        element_dir.mkdir(exist_ok=True)
+
+        element_dict = (
+            plotting_dict[element]
+            if element in plotting_dict
+            else plotting_dict['all']
+        )
+        mass_nums = list(element_dict)
+
+        if check_all_tag(mass_nums):
+            # Create range of all known mass numbers for element-agnostic
+            # iterable, up to second isomeric state (highest allowed in TENDL)
+            mass_range = range(1, 295)
+            mass_nums = list(mass_range)
+            for iso in tp.ISOMERIC_STATES[:2]:
+                mass_nums.extend([f'{a}{iso}' for a in mass_range])
+
+        for A in mass_nums:
+            bottom_dir = element_dir / f'{element}{A}'
+            bottom_dir.mkdir(exist_ok=True)
+            M = tp.ISOMERIC_STATES.find(str(A)[-1]) + 1
+            kza = str((
+                njt.elements[element] * 1000 + flagged_num_to_int(A)
+            ) * 10 + M)
+
+            MTs = (
+                element_dict[A]
+                if A in element_dict
+                else element_dict['all']
+            )
+
+            if not isinstance(MTs, list):
+                MTs = [MTs]
+    
+            if check_all_tag(MTs):
+                MTs = rxd.process_mt_data(rxd.load_mt_table(
+                    njt.set_directory() / 'mt_table.csv'
+                )).keys()
+
+            for MT in MTs:
+                fig, ax = plt.subplots(figsize=(10,6))
+                stair_plot = None
+                group_names = []
+
+                for dsv in data_sets:
+                    with open(dsv, 'r') as f:
+                        dsv_lines = f.readlines()
+
+                    group_name = dsv_lines[0].split()[-1]
+                    group_names.append(group_name)
+
+                    # If group structure is not contained in
+                    # openmc.mgxs.GROUP_STRUCTURES, a reference file must
+                    # exist in the CWD with a matching name to the group_name
+                    # containing the group bounds explicitly
+                    energy_bounds = GROUP_STRUCTURES.get(
+                        group_name, sorted(np.loadtxt(group_name))
+                    )
+
+                    xs = np.array([])
+                    for line in dsv_lines[1:-1]:
+                        rxn = line.split()
+                        pKZA, dKZA, dsv_MT, emitted = rxn[:4]
+                        if emitted == 'x':
+                            gas_type = rxd.GAS_DF.loc[
+                                rxd.GAS_DF['kza'] == int(dKZA), 'gas'
+                            ].iat[0]
+                            emitted = emitted.upper() + gas_type
+
+                        if kza == pKZA and MT == flagged_num_to_int(dsv_MT):
+                            xs = np.array(rxn[4:]).astype(float)
+                            break
+
+                    if xs.size > 0:
+                        stair_plot = ax.stairs(
+                            xs, energy_bounds[::-1], label=group_name
+                        )
+                
+                if stair_plot:
+                    title = (
+                        f'Energy-Dependent Neutron Cross-Sections for ' \
+                        f'$^{{{A}}}${element}(n,{emitted}):\n'
+                    )
+                    
+                    tendl_path = tendl_dir / f'{element}{A}.tendl'
+                    if tendl_path.is_file():
+                        tendl_xs, tendl_energies = extract_continuous_data(
+                            tendl_path, MT
+                        )
+                    if tendl_xs and tendl_energies:
+                        ax.plot(tendl_energies, tendl_xs, label='TENDL')
+                        title += 'TENDL (Continuous), '
+
+                    title += ', '.join(group_names) + ' (Groupwise)'
+
+                    ax.set_xscale('log')
+                    ax.set_yscale('log')
+                    ax.set_xlabel('Energy [eV]')
+                    ax.set_ylabel('Cross-Section [b]')
+                    ax.set_title(title)
+                    ax.grid()
+                    ax.legend()
+                    plt.savefig(
+                        bottom_dir / (
+                             f'{element}{A}_(n,{emitted})_' \
+                             f'{'_'.join(group_names)}.png'
+                        )
+                    )
+                    plt.close()
+
+            # Remove nuclide-level directories that did not produce any plots
+            del_if_empty(bottom_dir)
+
+        # Remove element-level directories that did not produce any plots
+        del_if_empty(element_dir)
+
+    print(
+        f'Cross-section plots saved to {top_dir}/, ' \
+        'organized by element, nuclide.'
+    )
+
+def main():
+    # Only load in yaml module when executing xs_plotting.py as a script,
+    # to allow for it to be used within preprocess_fendl3.py without
+    # additional necessary dependencies
+    from yaml import safe_load
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--yaml', '-y')
+    args = parser.parse_args()
+
+    with open(args.yaml, 'r') as f:
+        parameter_dict = safe_load(f)
+
+    plot_cross_sections(parameter_dict)
+
+if __name__ == '__main__':
+    main()

--- a/tools/ALARAJOYWrapper/xs_plotting.py
+++ b/tools/ALARAJOYWrapper/xs_plotting.py
@@ -4,7 +4,7 @@ import argparse
 from openmc.mgxs import GROUP_STRUCTURES
 import njoy_tools as njt
 import tendl_processing as tp
-from collections import defaultdict
+from collections import defaultdict, abc
 from pathlib import Path
 from pathlib._local import PosixPath 
 import reaction_data as rxd
@@ -216,7 +216,7 @@ def plot_cross_sections(plotting_dict):
                 else element_dict['all']
             )
 
-            if not isinstance(MTs, list):
+            if not isinstance(MTs, abc.Iterable) or isinstance(MTs, str):
                 MTs = [MTs]
     
             if check_all_tag(MTs):
@@ -224,7 +224,7 @@ def plot_cross_sections(plotting_dict):
                     njt.set_directory() / 'mt_table.csv'
                 )).keys()
 
-            for MT in MTs:
+            for MT in [flagged_num_to_int(MT) for MT in MTs]:
                 fig, ax = plt.subplots(figsize=(10,6))
                 stair_plot = None
                 group_names = []


### PR DESCRIPTION
Follows #285. Closes #286.

This PR creates a new module `xs_plotting.py` that can be used within or independently of the core preprocessor to produce stair plots of groupwise cross-sections alongside continuous-energy TENDL cross-sections. 

I've been putting this together following the discussion in the 6/22 meeting about the needs for some plotting tool for ALARAJOY-produced groupwise cross-sections. Given @gonuke's comment on #286 from this morning, these changes may be more expansive than desired for a single PR, but I wanted to open it still as a framing point for coming work on plotting tools.