### PR TITLE
Cross-Section Plotting -- Basic Function Only

### DIFF
--- a/tools/ALARAJOYWrapper/xs_plotting.py
+++ b/tools/ALARAJOYWrapper/xs_plotting.py
@@ -72,6 +72,5 @@ def plot_single_nuc_rxn_xs(
     ax.set_title(title)
     ax.grid()
     ax.legend()
-    print(ax.get_title())
 
     return ax

--- a/tools/ALARAJOYWrapper/xs_plotting.py
+++ b/tools/ALARAJOYWrapper/xs_plotting.py
@@ -1,5 +1,5 @@
 def plot_single_nuc_rxn_xs(
-    ax, element, A, emitted, continuous_dict={}, groupwise_dict={},
+    ax, element, A, emitted, continuous_dict={}, groupwise_dict={}
 ):
     """
     Create a plot for a singular nuclide/reaction's cross-sections vs. energy.
@@ -72,5 +72,6 @@ def plot_single_nuc_rxn_xs(
     ax.set_title(title)
     ax.grid()
     ax.legend()
+    print(ax.get_title())
 
     return ax

--- a/tools/ALARAJOYWrapper/xs_plotting.py
+++ b/tools/ALARAJOYWrapper/xs_plotting.py
@@ -1,4 +1,6 @@
-def plot_single_nuc_rxn_xs(ax, single_rxn_dict, element, A, emitted):
+def plot_single_nuc_rxn_xs(
+    ax, element, A, emitted, continuous_dict={}, groupwise_dict={},
+):
     """
     Create a plot for a singular nuclide/reaction's cross-sections vs. energy.
         Can be used to plot continuous TENDL data (not processed by ALARAJOY),
@@ -10,17 +12,23 @@ def plot_single_nuc_rxn_xs(ax, single_rxn_dict, element, A, emitted):
     Arguments:
         ax (matplotlib.axes._axes.Axes): Matplotlib Axes object of the plot
             being constructed.
-        single_rxn_dict (dict): Nested dictionary keyed at the highest level
-            by either the key "Continuous" for continuous TENDL data or the
-            name of the group structure according to which an array of cross-
-            sections were processed. The form of this data structure is as
-            follows:
+        element (str): Symbol of the element to which the nuclide being
+            plotted belongs.
+        A (str or int): Mass number for selected isonuclide.
+            If the target is a metastable isomer, "m" or "n" is written after 
+            the mass number, corresponding to the first or second metastable
+            states.
+        continuous_dict (dict, optional): Dictionary containing an individual
+            nuclide's continous TENDL cross-sections and energies for a given
+            reaction. Formatted as:
+                {'xs' : continuous_xs, 'energies' : continous_energies}
 
+            (Defaults to {})
+        groupwise_dict (dict, optional): Nested dictionary keyed at the
+            highest level by the name of the group structure according to
+            which an array of cross-sections were processed. The form of this
+            data structure is as follows:
                 {
-                    'continuous'   : {
-                        'xs'       : continuous_xs,
-                        'energies' : continuous_energies
-                    },
                     'group_name_1' : {
                         'xs'       : groupwise_xs,
                         'energies' : energy_group_bounds
@@ -31,12 +39,8 @@ def plot_single_nuc_rxn_xs(ax, single_rxn_dict, element, A, emitted):
                         'energies' : energy_group_bounds
                     },
                 }
-        element (str): Symbol of the element to which the nuclide being
-            plotted belongs.
-        A (str or int): Mass number for selected isonuclide.
-            If the target is a metastable isomer, "m" or "n" is written after 
-            the mass number, corresponding to the first or second metastable
-            states.
+
+            (Defaults to {})
 
     Returns:
         ax (matplotlib.axes._axes.Axes): Updated Matplotlib Axes object of the
@@ -48,11 +52,15 @@ def plot_single_nuc_rxn_xs(ax, single_rxn_dict, element, A, emitted):
         f'$^{{{A}}}${element}(n,{emitted}):\n'
     )
 
-    for data_set, arrays in single_rxn_dict.items():
-        if data_set == 'continuous':
-            ax.plot(arrays['energies'], arrays['xs'], label='TENDL')
-            title += 'TENDL (Continuous), '
-        else:
+    # Conditionally plot continous data
+    if continuous_dict:
+        ax.plot(
+            continuous_dict['energies'], continuous_dict['xs'], label='TENDL'
+        )
+
+    # Conditionally plot each group structure's data provided
+    if groupwise_dict:
+        for data_set, arrays in groupwise_dict.items():
             ax.stairs(arrays['xs'][::-1], arrays['energies'], label=data_set)
 
     ax.set_xscale('log')
@@ -61,7 +69,7 @@ def plot_single_nuc_rxn_xs(ax, single_rxn_dict, element, A, emitted):
     ax.set_ylabel('Cross-Section [b]')
     ax.set_title(
         title
-        + ', '.join([g for g in single_rxn_dict if g != 'continuous'])
+        + ', '.join([g for g in groupwise_dict if g != 'continuous'])
         + ' (Groupwise)'
     )
     ax.grid()

--- a/tools/ALARAJOYWrapper/xs_plotting.py
+++ b/tools/ALARAJOYWrapper/xs_plotting.py
@@ -18,6 +18,7 @@ def plot_single_nuc_rxn_xs(
             If the target is a metastable isomer, "m" or "n" is written after 
             the mass number, corresponding to the first or second metastable
             states.
+        emitted (str): Particle(s) emitted from a nuclear reaction.
         continuous_dict (dict, optional): Dictionary containing an individual
             nuclide's continous TENDL cross-sections and energies for a given
             reaction. Formatted as:

--- a/tools/ALARAJOYWrapper/xs_plotting.py
+++ b/tools/ALARAJOYWrapper/xs_plotting.py
@@ -1,0 +1,70 @@
+def plot_single_nuc_rxn_xs(ax, single_rxn_dict, element, A, emitted):
+    """
+    Create a plot for a singular nuclide/reaction's cross-sections vs. energy.
+        Can be used to plot continuous TENDL data (not processed by ALARAJOY),
+        alongside an arbitrary number of groupwise cross-sections according to
+        the group structure in which they were converted. Groupwise and
+        continuous data can be plotted individually if only one type is
+        provided.
+
+    Arguments:
+        ax (matplotlib.axes._axes.Axes): Matplotlib Axes object of the plot
+            being constructed.
+        single_rxn_dict (dict): Nested dictionary keyed at the highest level
+            by either the key "Continuous" for continuous TENDL data or the
+            name of the group structure according to which an array of cross-
+            sections were processed. The form of this data structure is as
+            follows:
+
+                {
+                    'continuous'   : {
+                        'xs'       : continuous_xs,
+                        'energies' : continuous_energies
+                    },
+                    'group_name_1' : {
+                        'xs'       : groupwise_xs,
+                        'energies' : energy_group_bounds
+                    },
+                    ...
+                    'group_name_n' : {
+                        'xs'       : groupwise_xs,
+                        'energies' : energy_group_bounds
+                    },
+                }
+        element (str): Symbol of the element to which the nuclide being
+            plotted belongs.
+        A (str or int): Mass number for selected isonuclide.
+            If the target is a metastable isomer, "m" or "n" is written after 
+            the mass number, corresponding to the first or second metastable
+            states.
+
+    Returns:
+        ax (matplotlib.axes._axes.Axes): Updated Matplotlib Axes object of the
+            plot being constructed.
+    """
+
+    title = (
+        f'Energy-Dependent Neutron Cross-Sections for ' \
+        f'$^{{{A}}}${element}(n,{emitted}):\n'
+    )
+
+    for data_set, arrays in single_rxn_dict.items():
+        if data_set == 'continuous':
+            ax.plot(arrays['energies'], arrays['xs'], label='TENDL')
+            title += 'TENDL (Continuous), '
+        else:
+            ax.stairs(arrays['xs'][::-1], arrays['energies'], label=data_set)
+
+    ax.set_xscale('log')
+    ax.set_yscale('log')
+    ax.set_xlabel('Energy [eV]')
+    ax.set_ylabel('Cross-Section [b]')
+    ax.set_title(
+        title
+        + ', '.join([g for g in single_rxn_dict if g != 'continuous'])
+        + ' (Groupwise)'
+    )
+    ax.grid()
+    ax.legend()
+
+    return ax

--- a/tools/ALARAJOYWrapper/xs_plotting.py
+++ b/tools/ALARAJOYWrapper/xs_plotting.py
@@ -62,16 +62,14 @@ def plot_single_nuc_rxn_xs(
     if groupwise_dict:
         for data_set, arrays in groupwise_dict.items():
             ax.stairs(arrays['xs'][::-1], arrays['energies'], label=data_set)
+        
+        title += ', '.join([g for g in groupwise_dict]) + ' (Groupwise)'
 
     ax.set_xscale('log')
     ax.set_yscale('log')
     ax.set_xlabel('Energy [eV]')
     ax.set_ylabel('Cross-Section [b]')
-    ax.set_title(
-        title
-        + ', '.join([g for g in groupwise_dict if g != 'continuous'])
-        + ' (Groupwise)'
-    )
+    ax.set_title(title)
     ax.grid()
     ax.legend()
 


### PR DESCRIPTION
Closes #286.

This PR is working backwards from the over-expansive version in #287, which tackles too many issues at once by simply introducing a cross-section plotting function that is capable of comparatively plotting different groupwise and continuous cross-section vs energy plots together for a given nuclide/reaction.