### PR TITLE
Cross-Section Plotting -- Continuous Data Extraction

### DIFF
--- a/tools/ALARAJOYWrapper/xs_plotting.py
+++ b/tools/ALARAJOYWrapper/xs_plotting.py
@@ -1,3 +1,4 @@
+import re
 import tendl_processing as tp
 
 def flagged_num_to_int(num):
@@ -13,7 +14,14 @@ def flagged_num_to_int(num):
         integer form.
     """
 
-    return int(''.join(char for char in str(num) if char.isdigit()))
+    re_match = re.match(r'^\d+', str(num))
+    if not re_match:
+        raise ValueError(
+            f'Invalid flagged number {num}. Must be formatted with numeric ' \
+            'characters before non-numeric characters.'
+        )
+    
+    return int(re_match.group())
 
 def extract_continuous_data(tendl_path, MT):
     """

--- a/tools/ALARAJOYWrapper/xs_plotting.py
+++ b/tools/ALARAJOYWrapper/xs_plotting.py
@@ -26,15 +26,15 @@ def extract_continuous_data(tendl_path, MT):
         MT (int): Reaction identifying number.
 
     Returns:
-        tendl_xs (list): Continuous-energy cross-sections for a given
-            nuclide-reaction combination from the original TENDL file. If the
-            provided reaction type does not exist in the TENDL file (such as
-            gas production totals, which are calculated by the data
-            preprocessor), then tendl_xs will be empty.
-        tendl_energies (list): Corresponding energies for the cross-sections
-            for a given nuclide-reaction combination from the original TENDL
-            file. If the provided reaction type does not exist in the TENDL
-            file), then tendl_energies will be empty.
+        continuous_dict (dict, optional): Dictionary containing an individual
+            nuclide's continous TENDL cross-sections and energies for a given
+            reaction. Formatted as:
+                {'xs' : continuous_xs, 'energies' : continous_energies}
+
+            If the provided reaction type does not exist in the TENDL file
+            (such as gas production totals, which are calculated by the data
+            preprocessor), then the dictionary values will be stored as empty
+            lists.
     """
 
     tendl_xs = []

--- a/tools/ALARAJOYWrapper/xs_plotting.py
+++ b/tools/ALARAJOYWrapper/xs_plotting.py
@@ -1,3 +1,57 @@
+import tendl_processing as tp
+
+def flagged_num_to_int(num):
+    """
+    Convert numerical values that may be in string form containing additional
+        tags (i.e. '26m' or '4*') left over from groupwise processing to their
+        base integer form.
+
+    num (int or str): Numerical value, which may be in string form with
+        additional tags such as 'm' or '*'.
+
+    num_int (int): Numerical value stripped of any non-numerical characters in
+        integer form.
+    """
+
+    return int(''.join(char for char in str(num) if char.isdigit()))
+
+def extract_continuous_data(tendl_path, MT):
+    """
+    For a given nuclide and reaction, extract its continuous-energy cross-
+        sections and corresponding energies from its original TENDL file.
+
+    Arguments:
+        tendl_path (pathlib._local.PosixPath): Path to the nuclide's original
+            TENDL file.
+        MT (int): Reaction identifying number.
+
+    Returns:
+        tendl_xs (list): Continuous-energy cross-sections for a given
+            nuclide-reaction combination from the original TENDL file. If the
+            provided reaction type does not exist in the TENDL file (such as
+            gas production totals, which are calculated by the data
+            preprocessor), then tendl_xs will be empty.
+        tendl_energies (list): Corresponding energies for the cross-sections
+            for a given nuclide-reaction combination from the original TENDL
+            file. If the provided reaction type does not exist in the TENDL
+            file), then tendl_energies will be empty.
+    """
+
+    tendl_xs = []
+    tendl_energies = []
+
+    file, _ = tp.create_endf_file_obj(tendl_path, 3)
+    MT = flagged_num_to_int(MT)
+    if MT in [MT.MT for MT in file.sections]:
+        section = file.section(MT).parse()
+        tendl_xs = list(section.cross_sections)
+        tendl_energies = list(section.energies)
+
+    return {
+        'xs'            :           tendl_xs,
+        'energies'      :     tendl_energies
+    }
+
 def plot_single_nuc_rxn_xs(
     ax, element, A, emitted, continuous_dict={}, groupwise_dict={}
 ):


### PR DESCRIPTION
Follows #288.

This PR introduces functionality to extract cross-sections and energies from a continuous-energy TENDL file and stored in a data structure of the form `{'xs' : tendl_xs, 'energies' : tendl_energies}` for the `continuous_dict` parameter in `xs_plotting.plot_single_nuc_rxn_xs()`.