### PR TITLE
Cross-Section Plotting -- Setting Image Filepaths According to Hierarchical Directory Structure

### DIFF
--- a/tools/ALARAJOYWrapper/xs_plotting.py
+++ b/tools/ALARAJOYWrapper/xs_plotting.py
@@ -115,7 +115,7 @@ def set_plot_save_path(
 
 def plot_single_nuc_rxn_xs(
     ax, element, A, emitted, tendl_dir,
-    continuous_dict={}, groupwise_dict={}, img_ext='png'
+    continuous_dict={}, groupwise_dict={}, saving=True, img_ext='png'
 ):
     """
     Create and save a plot for a singular nuclide/reaction's cross-sections
@@ -158,6 +158,10 @@ def plot_single_nuc_rxn_xs(
                 }
 
             (Defaults to {})
+        saving (bool, optional): Option to save the plot to an image file
+            within a hierarchical directory structure of TENDL-LIBRARY ->
+            ELEMENT -> NUCLIDE.
+            (Defaults to True)
         img_ext (str, optional): Option to set the image filetype for the plot
             to be saved, limited to Matplotlib filetypes: png, ps, pdf, svg.
             (Defaults to 'png')
@@ -193,8 +197,9 @@ def plot_single_nuc_rxn_xs(
     ax.grid()
     ax.legend()
 
-    plt.savefig(set_plot_save_path(
-        element, A, emitted, tendl_dir, groupwise_dict.keys(), img_ext
-    ))
+    if saving:
+        plt.savefig(set_plot_save_path(
+            element, A, emitted, tendl_dir, groupwise_dict.keys(), img_ext
+        ))
 
     return ax

--- a/tools/ALARAJOYWrapper/xs_plotting.py
+++ b/tools/ALARAJOYWrapper/xs_plotting.py
@@ -1,5 +1,6 @@
 import re
 import tendl_processing as tp
+from pathlib import Path
 
 def flagged_num_to_int(num):
     """
@@ -137,3 +138,49 @@ def plot_single_nuc_rxn_xs(
     ax.legend()
 
     return ax
+
+def set_plot_save_path(
+    element, A, tendl_dir, emitted, group_names, img_ext='png'
+):
+    """
+    For a given reaction's cross-section plot produced by
+        plot_single_nuc_rxn_xs(), ensure/create a directory storage structure
+        of TENDL-LIBRARY -> ELEMENT -> NUCLIDE to write the path at which the
+        plot can be saved by its reaction type within the nuclide-level sub-
+        directory.
+
+    Arguments:
+        element (str): Symbol of the element to which the nuclide being
+            plotted belongs.
+        A (str or int): Mass number for selected isonuclide.
+            If the target is a metastable isomer, "m" or "n" is written after 
+            the mass number, corresponding to the first or second metastable
+            states.
+        tendl_dir (pathlib._local.PosixPath): Path to the directory in which
+            the original TENDL data from which the cross-section data is
+            extracted or derived.
+        emitted (str): Particle(s) emitted from a nuclear reaction.
+        group_names (array-like): Iterable of all group-structures with data
+            included in the plot.
+        img_ext (str, optional): Option to set the image filetype for the plot
+            to be saved, limited to Matplotlib filetypes: png, ps, pdf, svg.
+            (Defaults to 'png')
+    
+    Returns:
+        save_path (pathlib._local.PosixPath): PNG filepath for a given
+            reaction plot of the format:
+            
+                TENDL_LIB_PLOTS/ELEMENT/NUCLIDE/RXN_WITH_GROUPS.png
+
+            For example, the Fe-56 (n,p) reaction plotting VITAMIN-J-175 group
+                data based on the continuous TENDL-2017 data would have the
+                filepath:
+
+                CWD/tendl2017_plots/Fe/Fe56/Fe56_(n,p)_VITAMIN-J-175.png
+    """
+
+    nuc = f'{element}{A}'
+    nuc_dir = Path(f'{tendl_dir}_plots') / element / nuc
+    nuc_dir.mkdir(parents=True, exist_ok=True)
+
+    return nuc_dir / f'{nuc}_(n,{emitted})_{"_".join(group_names)}.{img_ext}'

--- a/tools/ALARAJOYWrapper/xs_plotting.py
+++ b/tools/ALARAJOYWrapper/xs_plotting.py
@@ -156,8 +156,8 @@ def set_plot_save_path(
             If the target is a metastable isomer, "m" or "n" is written after 
             the mass number, corresponding to the first or second metastable
             states.
-        tendl_dir (pathlib._local.PosixPath): Path to the directory in which
-            the original TENDL data from which the cross-section data is
+        tendl_dir (pathlib._local.PosixPath or str): Path to the directory in
+            which the original TENDL data from which the cross-section data is
             extracted or derived.
         emitted (str): Particle(s) emitted from a nuclear reaction.
         group_names (array-like or str): Iterable of all group structures with
@@ -169,13 +169,13 @@ def set_plot_save_path(
             (Defaults to 'png')
     
     Returns:
-        save_path (pathlib._local.PosixPath): PNG filepath for a given
-            reaction plot of the format:
+        save_path (pathlib._local.PosixPath): Filepath for a given reaction
+            plot of the format:
             
-                TENDL_LIB_PLOTS/ELEMENT/NUCLIDE/RXN_WITH_GROUPS.png
+                TENDL_LIB_PLOTS/ELEMENT/NUCLIDE/RXN_WITH_GROUPS.img_ext
 
             For example, the Fe-56 (n,p) reaction plotting VITAMIN-J-175 group
-                data based on the continuous TENDL-2017 data would have the
+                data based on the continuous TENDL-2017 data could have the
                 filepath:
 
                 CWD/tendl2017_plots/Fe/Fe56/Fe56_(n,p)_VITAMIN-J-175.png

--- a/tools/ALARAJOYWrapper/xs_plotting.py
+++ b/tools/ALARAJOYWrapper/xs_plotting.py
@@ -160,8 +160,10 @@ def set_plot_save_path(
             the original TENDL data from which the cross-section data is
             extracted or derived.
         emitted (str): Particle(s) emitted from a nuclear reaction.
-        group_names (array-like): Iterable of all group-structures with data
-            included in the plot.
+        group_names (array-like or str): Iterable of all group structures with
+            data included in the plot. If only a single group structure has
+            data being plotted, then this parameter can be a string of the
+            singular group name.
         img_ext (str, optional): Option to set the image filetype for the plot
             to be saved, limited to Matplotlib filetypes: png, ps, pdf, svg.
             (Defaults to 'png')
@@ -178,6 +180,9 @@ def set_plot_save_path(
 
                 CWD/tendl2017_plots/Fe/Fe56/Fe56_(n,p)_VITAMIN-J-175.png
     """
+
+    if isinstance(group_names, str):
+        group_names = [group_names]
 
     nuc = f'{element}{A}'
     nuc_dir = Path(f'{tendl_dir}_plots') / element / nuc

--- a/tools/ALARAJOYWrapper/xs_plotting.py
+++ b/tools/ALARAJOYWrapper/xs_plotting.py
@@ -114,8 +114,7 @@ def set_plot_save_path(
     return nuc_dir / f'{nuc}_(n,{emitted})_{"_".join(group_names)}.{img_ext}'
 
 def plot_single_nuc_rxn_xs(
-    ax, element, A, emitted, tendl_dir,
-    continuous_dict={}, groupwise_dict={}, saving=True, img_ext='png'
+    ax, element, A, emitted, continuous_dict={}, groupwise_dict={}
 ):
     """
     Create and save a plot for a singular nuclide/reaction's cross-sections
@@ -158,13 +157,6 @@ def plot_single_nuc_rxn_xs(
                 }
 
             (Defaults to {})
-        saving (bool, optional): Option to save the plot to an image file
-            within a hierarchical directory structure of TENDL-LIBRARY ->
-            ELEMENT -> NUCLIDE.
-            (Defaults to True)
-        img_ext (str, optional): Option to set the image filetype for the plot
-            to be saved, limited to Matplotlib filetypes: png, ps, pdf, svg.
-            (Defaults to 'png')
 
     Returns:
         ax (matplotlib.axes._axes.Axes): Updated Matplotlib Axes object of the
@@ -196,10 +188,5 @@ def plot_single_nuc_rxn_xs(
     ax.set_title(title)
     ax.grid()
     ax.legend()
-
-    if saving:
-        plt.savefig(set_plot_save_path(
-            element, A, emitted, tendl_dir, groupwise_dict.keys(), img_ext
-        ))
 
     return ax

--- a/tools/ALARAJOYWrapper/xs_plotting.py
+++ b/tools/ALARAJOYWrapper/xs_plotting.py
@@ -1,5 +1,6 @@
 import re
 import tendl_processing as tp
+import matplotlib.pyplot as plt
 from pathlib import Path
 
 def flagged_num_to_int(num):
@@ -61,16 +62,68 @@ def extract_continuous_data(tendl_path, MT):
         'energies'      :     tendl_energies
     }
 
-def plot_single_nuc_rxn_xs(
-    ax, element, A, emitted, continuous_dict={}, groupwise_dict={}
+def set_plot_save_path(
+    element, A, emitted, tendl_dir, group_names, img_ext='png'
 ):
     """
-    Create a plot for a singular nuclide/reaction's cross-sections vs. energy.
-        Can be used to plot continuous TENDL data (not processed by ALARAJOY),
-        alongside an arbitrary number of groupwise cross-sections according to
-        the group structure in which they were converted. Groupwise and
-        continuous data can be plotted individually if only one type is
-        provided.
+    For a given reaction's cross-section plot produced by
+        plot_single_nuc_rxn_xs(), ensure/create a directory storage structure
+        of TENDL-LIBRARY -> ELEMENT -> NUCLIDE to write the path at which the
+        plot can be saved by its reaction type within the nuclide-level sub-
+        directory.
+
+    Arguments:
+        element (str): Symbol of the element to which the nuclide being
+            plotted belongs.
+        A (str or int): Mass number for selected isonuclide.
+            If the target is a metastable isomer, "m" or "n" is written after 
+            the mass number, corresponding to the first or second metastable
+            states.
+        emitted (str): Particle(s) emitted from a nuclear reaction.
+        tendl_dir (pathlib._local.PosixPath or str): Path to the directory in
+            which the original TENDL data from which the cross-section data is
+            extracted or derived.
+        group_names (array-like or str): Iterable of all group structures with
+            data included in the plot. If only a single group structure has
+            data being plotted, then this parameter can be a string of the
+            singular group name.
+        img_ext (str, optional): Option to set the image filetype for the plot
+            to be saved, limited to Matplotlib filetypes: png, ps, pdf, svg.
+            (Defaults to 'png')
+    
+    Returns:
+        save_path (pathlib._local.PosixPath): Filepath for a given reaction
+            plot of the format:
+            
+                TENDL_LIB_PLOTS/ELEMENT/NUCLIDE/RXN_WITH_GROUPS.img_ext
+
+            For example, the Fe-56 (n,p) reaction plotting VITAMIN-J-175 group
+                data based on the continuous TENDL-2017 data could have the
+                filepath:
+
+                CWD/tendl2017_plots/Fe/Fe56/Fe56_(n,p)_VITAMIN-J-175.png
+    """
+
+    if isinstance(group_names, str):
+        group_names = [group_names]
+
+    nuc = f'{element}{A}'
+    nuc_dir = Path(f'{tendl_dir}_plots') / element / nuc
+    nuc_dir.mkdir(parents=True, exist_ok=True)
+
+    return nuc_dir / f'{nuc}_(n,{emitted})_{"_".join(group_names)}.{img_ext}'
+
+def plot_single_nuc_rxn_xs(
+    ax, element, A, emitted, tendl_dir,
+    continuous_dict={}, groupwise_dict={}, img_ext='png'
+):
+    """
+    Create and save a plot for a singular nuclide/reaction's cross-sections
+        vs. energy. Can be used to plot continuous TENDL data (not processed
+        by ALARAJOY), alongside an arbitrary number of groupwise cross-
+        sections according to the group structure in which they were
+        converted. Groupwise and continuous data can be plotted individually
+        if only one type is provided.
 
     Arguments:
         ax (matplotlib.axes._axes.Axes): Matplotlib Axes object of the plot
@@ -105,6 +158,9 @@ def plot_single_nuc_rxn_xs(
                 }
 
             (Defaults to {})
+        img_ext (str, optional): Option to set the image filetype for the plot
+            to be saved, limited to Matplotlib filetypes: png, ps, pdf, svg.
+            (Defaults to 'png')
 
     Returns:
         ax (matplotlib.axes._axes.Axes): Updated Matplotlib Axes object of the
@@ -137,55 +193,8 @@ def plot_single_nuc_rxn_xs(
     ax.grid()
     ax.legend()
 
+    plt.savefig(set_plot_save_path(
+        element, A, emitted, tendl_dir, groupwise_dict.keys(), img_ext
+    ))
+
     return ax
-
-def set_plot_save_path(
-    element, A, tendl_dir, emitted, group_names, img_ext='png'
-):
-    """
-    For a given reaction's cross-section plot produced by
-        plot_single_nuc_rxn_xs(), ensure/create a directory storage structure
-        of TENDL-LIBRARY -> ELEMENT -> NUCLIDE to write the path at which the
-        plot can be saved by its reaction type within the nuclide-level sub-
-        directory.
-
-    Arguments:
-        element (str): Symbol of the element to which the nuclide being
-            plotted belongs.
-        A (str or int): Mass number for selected isonuclide.
-            If the target is a metastable isomer, "m" or "n" is written after 
-            the mass number, corresponding to the first or second metastable
-            states.
-        tendl_dir (pathlib._local.PosixPath or str): Path to the directory in
-            which the original TENDL data from which the cross-section data is
-            extracted or derived.
-        emitted (str): Particle(s) emitted from a nuclear reaction.
-        group_names (array-like or str): Iterable of all group structures with
-            data included in the plot. If only a single group structure has
-            data being plotted, then this parameter can be a string of the
-            singular group name.
-        img_ext (str, optional): Option to set the image filetype for the plot
-            to be saved, limited to Matplotlib filetypes: png, ps, pdf, svg.
-            (Defaults to 'png')
-    
-    Returns:
-        save_path (pathlib._local.PosixPath): Filepath for a given reaction
-            plot of the format:
-            
-                TENDL_LIB_PLOTS/ELEMENT/NUCLIDE/RXN_WITH_GROUPS.img_ext
-
-            For example, the Fe-56 (n,p) reaction plotting VITAMIN-J-175 group
-                data based on the continuous TENDL-2017 data could have the
-                filepath:
-
-                CWD/tendl2017_plots/Fe/Fe56/Fe56_(n,p)_VITAMIN-J-175.png
-    """
-
-    if isinstance(group_names, str):
-        group_names = [group_names]
-
-    nuc = f'{element}{A}'
-    nuc_dir = Path(f'{tendl_dir}_plots') / element / nuc
-    nuc_dir.mkdir(parents=True, exist_ok=True)
-
-    return nuc_dir / f'{nuc}_(n,{emitted})_{"_".join(group_names)}.{img_ext}'


### PR DESCRIPTION
Follows #288, independent of #289.

This PR introduces a concise function to recreate the file saving structure originally proposed in #287, but in a much more concise and modular way. This still employs the same hierarchical directory structure of: `TENDL_DATA_SOURCE->ELEMENT->NUCLIDE`, with each reaction plot having its own unique filepath within the nuclide-level directory (with the possibility of multiple versions of a single reaction for different combinations of group structure comparisons).  