### PR TITLE
Cross-Section Plotting -- Including Group Name/MTs in DSV

### DIFF
--- a/src/DataLib/ALARAJOY.cpp
+++ b/src/DataLib/ALARAJOY.cpp
@@ -33,14 +33,20 @@ void ALARAJOYLib::loadDSVData()
     currentParent = -1;
     DSVRow row;
 
-    // Read header containing energy group number
-    inTrans >> nGroups;
+    // Read header containing energy group number in first entry
+    std::string headerLine;
+    std::getline(inTrans, headerLine);
+    std::istringstream headerStream(headerLine);
+    headerStream >> nGroups;
 
     // Extract Parent KZA until EOF at pKZA == -1
     while ((inTrans >> row.parentKZA) && row.parentKZA != -1)
     {
-        // Extract Daughter KZA, emitted particles, and non-zero groups
-        inTrans >> row.daughterKZA >> row.emittedParticles;
+        // Store MT as temporary variable
+        int MT;
+
+        // Extract Daughter KZA, emitted particles, non-zero groups; pass MT
+        inTrans >> row.daughterKZA >> MT >> row.emittedParticles;
 
         /* Iterate through rest of line for cross sections 
            based on non-zero groups*/

--- a/src/DataLib/ALARAJOY.cpp
+++ b/src/DataLib/ALARAJOY.cpp
@@ -34,10 +34,8 @@ void ALARAJOYLib::loadDSVData()
     DSVRow row;
 
     // Read header containing energy group number in first entry
-    std::string headerLine;
-    std::getline(inTrans, headerLine);
-    std::istringstream headerStream(headerLine);
-    headerStream >> nGroups;
+    std::string groupName;
+    inTrans >> nGroups >> groupname;
 
     // Extract Parent KZA until EOF at pKZA == -1
     while ((inTrans >> row.parentKZA) && row.parentKZA != -1)

--- a/src/DataLib/ALARAJOY.cpp
+++ b/src/DataLib/ALARAJOY.cpp
@@ -35,7 +35,7 @@ void ALARAJOYLib::loadDSVData()
 
     // Read header containing energy group number in first entry
     std::string groupName;
-    inTrans >> nGroups >> groupname;
+    inTrans >> nGroups >> groupName;
 
     // Extract Parent KZA until EOF at pKZA == -1
     while ((inTrans >> row.parentKZA) && row.parentKZA != -1)

--- a/tools/ALARAJOYWrapper/README.md
+++ b/tools/ALARAJOYWrapper/README.md
@@ -43,7 +43,7 @@ python preprocess_fendl3.py -h
 
 
 ## Data Output
-Running `preprocess_fendl3.py` will return the file path to the resultant space-delimited DSV file containing transmutation reaction pathways for the neutron activation of the given isotope(s). Each row in the DSV represents a different reaction, and contains the following data needed by ALARA for a library conversion:
+Running `preprocess_fendl3.py` will return the file path to the resultant space-delimited DSV file containing transmutation reaction pathways for the neutron activation of the given isotope(s). The header of this DSV file will contain two entries, the number of groups of the group structure according to which the data was converted and the name of said group-structure. Each row in the DSV represents a different reaction, and contains the following data needed by ALARA for a library conversion:
 
 - Parent KZA: Unique isotope identifier for the parent isotope in the format **ZZAAAM**, where ZZ is the isotope's atomic number, AAA is the mass number, and M is the isomeric state (0 if non-excited).
 - Daughter KZA: Unique isotope identifier of the daughter isotope produced from a particular transmutation reaction in the format **ZZAAAM**.
@@ -58,10 +58,9 @@ Running `preprocess_fendl3.py` will return the file path to the resultant space-
 
   For reactions with multiple emitted particles, the format of the text string is along the lines '3n2p', representing an emission of three neutrons and two protons. An emission containing only one of a certain particle will just contain the particle identifier, without any numerical tag (e.g. 'n' for a single neutron).
 
-- Non-Zero Groups: Count of total number of energy groups in the Vitamin-J 175 energy group structure with non-zero neutron cross sections.
 - Cross Sections: List of all non-zero neutron cross sections.
 
-It should be noted that TENDL 2017 activation data contains many reactions that leave the residual nucleus in various quantized excited states, potentially up to a 40<sup>th</sup> excited state. Most of these daughter isomers, however, are extremely short-lived and lack decay data. When converting an ALARAJOY DSV file in ALARA, as discussed below, an EAF decay library is required, given that FENDL3.2x only contains activation data. Cross-referencing exotic isomers against this decay data ensures that ultra-short-lived reaction products are not passed on to ALARA's library conversion appearing as stable nuclides. Rather, the lack of decay data signifies such a short half-life that decay evaluations are not practical. For excited daughter nuclides produced from a given reaction lacking corresponding EAAF decay data, ALARAJOY will incrementally de-excite the nuclear state one-by-one down to the next lowest energy level with known decay data (or ultimately to ground).
+It should be noted that TENDL 2017 activation data contains many reactions that leave the residual nucleus in various quantized excited states, potentially up to a 40<sup>th</sup> excited state. Most of these daughter isomers, however, are extremely short-lived and lack decay data. When converting an ALARAJOY DSV file in ALARA, as discussed below, an EAF decay library is required, given that FENDL3.2x only contains activation data. Cross-referencing exotic isomers against this decay data ensures that ultra-short-lived reaction products are not passed on to ALARA's library conversion appearing as stable nuclides. Rather, the lack of decay data signifies such a short half-life that decay evaluations are not practical. For excited daughter nuclides produced from a given reaction lacking corresponding EAF decay data, ALARAJOY will incrementally de-excite the nuclear state one-by-one down to the next lowest energy level with known decay data (or ultimately to ground).
 
 ## Application of Processed Data to ALARA Data Conversion Methods
 Data library conversion to ALARA binary libraries is done with the `convert_lib` input block in the ALARA input file. Converting preprocessed TENDL data contained in the resultant space-delimited DSV from ALARAJOYWrapper is done as such in the input file:

--- a/tools/ALARAJOYWrapper/preprocess_fendl3.py
+++ b/tools/ALARAJOYWrapper/preprocess_fendl3.py
@@ -327,13 +327,14 @@ def combine_daughter_pathways(gas_filtered, nGroups):
 
     return gas_filtered
 
-def rxn_to_str(parent, daughter, rxn):
+def rxn_to_str(parent, daughter, MT, rxn):
     """
     Generate the list of strings to be written in a single row of the DSV file.
 
     Arguments:
         parent (int): KZA of the reaction's parent nuclide.
         daughter (int): KZA of the reaction's daughter nuclide.
+        MT (int): Reaction identifying number.
         rxn (dict): Dictionary for the given reaction containing cross-section
             and emitted particle data.
 
@@ -341,17 +342,18 @@ def rxn_to_str(parent, daughter, rxn):
         dsv_row (str): Joined string of all row data for a single reaction.
     """
 
-    dsv_row = f'{parent} {daughter} {rxn['emitted']} '
-    dsv_row += ' '.join(str(xs) for xs in rxn['xsections'])
+    dsv_row = f'{parent} {daughter} {MT} {rxn['emitted']} '
 
-    return dsv_row
+    return dsv_row + ' '.join(str(xs) for xs in rxn['xsections'])
 
-def write_dsv(dsv_path, all_rxns, nGroups):
+def write_dsv(dsv_path, all_rxns, nGroups, group_name):
     """
     Write out a space-delimited DSV file from the list of dictionaries,
         dsv_path, produced by iterating through each reaction of each isotope
         to be processed. Each row in the resultant DSV file is ordered as such:
-            pKZA dKZA emitted_particles non_zero_groups xs_1 xs_2 ... xs_n
+        
+            pKZA dKZA MT emitted_particles non_zero_groups xs_1 xs_2 ... xs_n
+        
         Each row can have different lengths, as only non-zero cross-sections
         are written out. The file is sorted by ascending parent KZA value.
 
@@ -370,19 +372,23 @@ def write_dsv(dsv_path, all_rxns, nGroups):
                     }
                 }    
             }
+        group_name (str): Name of the group structure into which cross-
+            sections were converted.
 
     Returns:
         None 
     """
 
     with open(dsv_path, 'w') as dsv:
-        dsv.write(str(nGroups) + '\n')
+        dsv.write(f'{nGroups} {group_name}\n')
         for parent in sorted(all_rxns):
             for daughter in all_rxns[parent]:
                 if parent != daughter:
-                    for rxn in all_rxns[parent][daughter].values():
+                    for MT, rxn in all_rxns[parent][daughter].items():
                         if rxn['xsections'].sum() > 0:
-                            dsv.write(f'{rxn_to_str(parent,daughter,rxn)}\n')
+                            dsv.write(
+                                f'{rxn_to_str(parent, daughter, MT, rxn)}\n'
+                            )
         # End of File (EOF) signifier to be read by ALARAJOY
         dsv.write(str(-1))
 
@@ -454,7 +460,7 @@ def main():
         gas_filtered = combine_daughter_pathways(gas_filtered, nGroups)
 
     dsv_path = dir / 'cumulative_gendf_data.dsv'
-    write_dsv(dsv_path, gas_filtered, nGroups)
+    write_dsv(dsv_path, gas_filtered, nGroups, group_name)
     print(
         f'Neutron activation cross-sections converted to {nGroups} groups ' \
         f'according to the {group_name} group structure.'


### PR DESCRIPTION
This PR makes a minor modification to the canonical format an ALARAJOY DSV to now include the name of the group structure according to which the groupwise data was converted in the first line after `nGroups` and for each reaction row to include the MT value corresponding to said reaction. Accordingly, `src/DataLib/ALARAJOY.cpp` is updated to handle this new format, without changing the data that it passes on to the rest of the ALARA binary library construction pipeline.

The motivation for this PR is that in order to create a standalone script for `xs_plotting` that will allow users to supply different DSV files as input, these additional pieces of data will be useful. Particularly being able to read in the group name from a DSV file is helpful in clarifying beyond just the group number count, should there be any group structures that share the same number of groups but which are not the same.