### PR TITLE
Fixing MT variable type in ALARAJOY DSV parser

### DIFF
--- a/src/DataLib/ALARAJOY.cpp
+++ b/src/DataLib/ALARAJOY.cpp
@@ -41,7 +41,7 @@ void ALARAJOYLib::loadDSVData()
     while ((inTrans >> row.parentKZA) && row.parentKZA != -1)
     {
         // Store MT as temporary variable
-        int MT;
+        std::string MT;
 
         // Extract Daughter KZA, emitted particles, non-zero groups; pass MT
         inTrans >> row.daughterKZA >> MT >> row.emittedParticles;


### PR DESCRIPTION
This PR fixes a small error introduced in #293 in which the temporary `MT` variable was set as an integer. This was problematic because MT values that correspond to excitations reactions will have a `'*'` appended to them and therefore cannot be read in as integers. Given that the MT value in the `ALARAJOY::loadDSVData()` is only needed for temporary storage, changing this variable type to a string resolves this issue without need for further editing of the MT value post-facto.