### PR TITLE
Fixing `flagged_num_to_int()` negative number handling

### DIFF
--- a/tools/ALARAJOYWrapper/xs_plotting.py
+++ b/tools/ALARAJOYWrapper/xs_plotting.py
@@ -17,7 +17,7 @@ def flagged_num_to_int(num):
         integer form.
     """
 
-    re_match = re.match(r'^\d+', str(num))
+    re_match = re.match(r'^-?\d+', str(num))
     if not re_match:
         raise ValueError(
             f'Invalid flagged number {num}. Must be formatted with numeric ' \


### PR DESCRIPTION
This PR fixes a small bug in `xs_plotting.flagged_num_to_int()` regular expression handling that excluded negative numbers to be treated as readable integers. This is problematic because the data preprocessor can output MT values of -1 for the `special_MT` handling in `tendl_processing.iterate_MTs()`.
