### PR TITLE
Handling all-zero series in alara_output_plotting

### DIFF
--- a/tools/alara_output_processing/alara_output_plotting.py
+++ b/tools/alara_output_processing/alara_output_plotting.py
@@ -873,9 +873,10 @@ def plot_single_response(
                     )
 
             t = piv.columns
-            last_nonzero_time = t[np.flatnonzero(series)[-1]]
-            if last_nonzero_time > tmax:
-                tmax = last_nonzero_time
+            if series.sum() > 0:
+                last_nonzero_time = t[np.flatnonzero(series)[-1]]
+                if last_nonzero_time > tmax:
+                    tmax = last_nonzero_time
 
             plot_or_scatter(
                 ax=ax,

--- a/tools/alara_output_processing/alara_output_plotting.py
+++ b/tools/alara_output_processing/alara_output_plotting.py
@@ -873,8 +873,9 @@ def plot_single_response(
                     )
 
             t = piv.columns
-            if series.sum() > 0:
-                last_nonzero_time = t[np.flatnonzero(series)[-1]]
+            non_zeroes = np.flatnonzero(series)
+            if non_zeroes.size > 0:
+                last_nonzero_time = t[non_zeroes[-1]]
                 if last_nonzero_time > tmax:
                     tmax = last_nonzero_time
 


### PR DESCRIPTION
This PR introduces a small check to the conditional `tmax` calculation in `alara_output_plotting.plot_single_response()`, which calculates the last non-zero time of a series using `np.flatnonzero(series)[-1]`. If `series` is an array exclusively containing zeroes, however, then `np.flatnonzero()` will return an array of size 0, producing an `IndexError` if indexed by `-1`. To protect against this, this PR puts all of the `tmax` calculation block under the conditional that the `series` contains any non-zero values, and therefore can yield a non-empty array when input to `np.flatnonzero()`.