### PR TITLE
Making preprocessing more efficient by reducing parsing instances

### DIFF
--- a/tools/ALARAJOYWrapper/README.md
+++ b/tools/ALARAJOYWrapper/README.md
@@ -18,7 +18,11 @@ This preprocessor uses [NJOY 2016](https://github.com/njoy/NJOY2016) Nuclear Dat
   * [Warnings](https://docs.python.org/3/library/warnings.html)
 - Generic Python packages
   * [Matplotlib.pyplot](https://matplotlib.org/3.5.3/api/_as_gen/matplotlib.pyplot.html)
-  * [NumPy](https://numpy.org/install/)
+  * [NumPy](https://numpy.org/install/) ([numpy.f2py](https://numpy.org/doc/stable/f2py/) is used for Fortran interfacing, which depends on the following):
+    * C-compiler (i.e. [gcc](https://hprc.tamu.edu/kb/Software/GNU-Compiler-Collection/#gcc-versions))
+    * Fortran-compiler (i.e. [gfortran](https://fortran-lang.org/learn/os_setup/install_gfortran/))
+    * [Meson](https://mesonbuild.com/)
+    * [Ninja](https://github.com/ninja-build/ninja.git)
   * [Pandas](https://pandas.pydata.org/docs/getting_started/install.html)
   * [PyYAML](https://pyyaml.org/wiki/PyYAMLDocumentation) (only needed if running `xs_plotting.py` as an independent script.)
 - Domain-specific packages

--- a/tools/ALARAJOYWrapper/njoy_endf_wrapper.f90
+++ b/tools/ALARAJOYWrapper/njoy_endf_wrapper.f90
@@ -1,0 +1,59 @@
+! ===========================
+! This lightweight NJOY wrapper accesses the NJOY ENDF module's utility
+! function endf.terpa() to make use of NJOY's built-in interpolation 
+! functionality to apply the appropriate interpolation schemes. The
+! designation for these schemes are encoded within the TAB1 record header 
+! variable INT, representing one of the following interpolation schemes, as
+! laid out in the ENDF-6 manual
+! (https://www.nndc.bnl.gov/endfdocs/ENDF-102-2023.pdf), under section 0.5.2
+! ("Interpolation Laws"):
+!
+!     INT   | Interpolation Scheme
+!     1     | y is constant in x (constant, histogram)
+!     2     | y is linear in x (linear-linear)
+!     3     | y is linear in ln(x) (linear-log)
+!     4     | ln(y) is linear in x (log-linear)
+!     5     | ln(y) is linear in ln(x) (log-log)
+!     6     | special one-dimensional interpolation law, used for charged-
+!           | particle cross sections only
+!     11-25 | method of corresponding points (follow interpolation laws 1-5)
+!     21-25 | unit base interpolation (follow interpolation laws of 1-5)
+!
+! This module's incorporation and usage within ALARAJOYWrapper is managed by
+! njoy_tools.import_njoy_endf_wrapper(), which conditionally compiles this
+! Fortran file to an executable using numpy.f2py (if such an executable has
+! not already been created) and importing njoy_endf_wrapper as a Python
+! package. This allows the subroutine interpolate_tab1() to be callable within
+! ALARAJOYWrapper, which is necessary for the construction of pathway-specific
+! reaction cross-section from MF9 multiplicities multiplied by MF3 cumulative
+! cross-sections (see xs_plotting.extract_continuous_data() for specific use-
+! case implementation).
+! ===========================
+
+module njoy_endf_wrapper
+
+   use endf
+   implicit none
+
+contains
+
+   subroutine interpolate_tab1(tab1, x, y)
+
+      real(kind=8), intent(in) :: tab1(:)
+      real(kind=8), intent(in) :: x(:)
+      real(kind=8), intent(out) :: y(size(x))
+
+      integer :: i
+      integer :: ip, ir, idis
+      real(kind=8) :: xnext
+
+      ip = 2
+      ir = 1
+
+      do i = 1, size(x)
+         call terpa(y(i), x(i), xnext, idis, tab1, ip, ir)
+      end do
+
+   end subroutine interpolate_tab1
+
+end module njoy_endf_wrapper

--- a/tools/ALARAJOYWrapper/njoy_tools.py
+++ b/tools/ALARAJOYWrapper/njoy_tools.py
@@ -4,6 +4,8 @@ import subprocess
 from pathlib import Path
 import re
 import numpy as np
+from sys import executable
+from shutil import which
 
 def set_directory():
     '''
@@ -700,3 +702,48 @@ def cleanup_njoy_files(element, A):
     output_dir = dir / 'njoy_outputs'
     output_dir.mkdir(exist_ok=True)
     Path('output').rename(output_dir / f'njoy_output_{element}{A}.out')
+
+def import_njoy_endf_wrapper():
+    """
+    Import the njoy_endf_wrapper module defined by the targeted NJOY-wrapper
+        njoy_endf_wrapper.f90. This wrapper utilizes the NJOY function
+        `endf.terpa()`, which interpolates TAB1 data according to the encoded
+        interpolation scheme(s). If the module cannot be accessed, compile
+        njoy_endf_wrapper.f90 to a CPython executable using NumPy.f2py and
+        subsequently import the module.
+
+    Arguments:
+        None
+
+    Returns:
+        njoy_endf_wrapper.njoy_endf_wrapper (fortran object): Python module of
+            the compiled njoy_endf_wrapper.f90 NJOY wrapper containing the
+            subroutine `interpolate_tab1()`, which can be used to apply
+            `endf.terpa()` to interpolate TAB1 according to the encoded
+            interpolation scheme(s).
+    """
+
+    try:
+        import njoy_endf_wrapper
+    
+    except (ModuleNotFoundError, ImportError):
+        njoy_dir = Path(which('njoy')).parent
+        subprocess.run(
+            [
+                executable,
+                '-m',
+                'numpy.f2py',
+                '-c',
+                '-m',
+                'njoy_endf_wrapper',
+                str(Path(__file__).parent / 'njoy_endf_wrapper.f90'),
+                f'-I{njoy_dir / "fortran_modules"}',
+                f'-L{njoy_dir}',
+                '-lnjoy'
+            ],
+            check=True,
+            cwd=Path.cwd()
+        )
+        import njoy_endf_wrapper
+    
+    return njoy_endf_wrapper.njoy_endf_wrapper

--- a/tools/ALARAJOYWrapper/preprocess_fendl3.py
+++ b/tools/ALARAJOYWrapper/preprocess_fendl3.py
@@ -11,6 +11,7 @@ import logging
 from pathlib import Path
 from collections import defaultdict
 from subprocess import TimeoutExpired
+from endf_parserpy import EndfParserPy
 
 def make_argparser():
     parser = argparse.ArgumentParser()
@@ -482,6 +483,9 @@ def store_results(
         dsv.write(f'{nGroups} {group_name}\n')
         for parent in sorted(all_rxns):
             element, A = tp.interpret_KZA(parent)
+            endf_dict = EndfParserPy().parsefile(
+                tendl_dir / f'{element}{A}.tendl'
+            )
             for daughter in all_rxns[parent]:
                 if parent != daughter:
                     for MT, rxn in all_rxns[parent][daughter].items():
@@ -501,8 +505,7 @@ def store_results(
                                 )
 
                                 continuous_dict = xp.extract_continuous_data(
-                                    tendl_dir / f'{element}{A}.tendl',
-                                    xp.flagged_num_to_int(MT)
+                                    endf_dict, MT
                                 )
 
                                 energies = njt.load_external_group_struct(
@@ -521,7 +524,7 @@ def store_results(
                                 plot_path = xp.set_plot_save_path(
                                     element, A, emitted, tendl_dir, group_name
                                 )
-                                
+
                                 plt.savefig(plot_path)
 
         if plotting:

--- a/tools/ALARAJOYWrapper/preprocess_fendl3.py
+++ b/tools/ALARAJOYWrapper/preprocess_fendl3.py
@@ -11,7 +11,6 @@ import logging
 from pathlib import Path
 from collections import defaultdict
 from subprocess import TimeoutExpired
-from endf_parserpy import EndfParserPy
 
 def make_argparser():
     parser = argparse.ArgumentParser()
@@ -116,7 +115,7 @@ def configure_logging(redirect_warnings=False):
 
 def process_pendf(
     material_id, MTs, pKZA, mt_dict, temperature,
-    tendl_path, tendl_dir, unresr_err_cases
+    endf_dict, tendl_dir, unresr_err_cases
 ):
     """
     Prepare and run initial NJOY run with MODER, RECONR, BROADR, UNRESR, and
@@ -134,8 +133,8 @@ def process_pendf(
         MTs (set): Set of all MTs from the original TENDL file.
         mt_dict (dict): Dictionary formatted data structure for mt_table.csv.
         temperature (float): Temperature at which to run NJOY modules.
-        tendl_path (pathlib._local.PosixPath): Path to the original,
-            unmodified TENDL file.
+        endf_dict (dict): Nested EndfParserPy-formatted dictionary containing
+            all parsed nuclear data from a TENDL file.
         tendl_dir (pathlib._local.PosixPath): Path to the directory in which
             the original TENDL nuclide files are contained.
         unresr_err_cases (list of str): List of all nuclides that required an
@@ -217,11 +216,9 @@ def process_pendf(
     else:
         njoy_error += prep_error
 
-    pendf_MTs = set(tp.parse_endf_file_level_data(
-        pendf_path, endf_format='pendf'
-    )[0])
+    pendf_MTs = set(tp.parse_endf_data(pendf_path, endf_format='pendf')[1])
     MTs |= pendf_MTs.intersection(set(rxd.GAS_DF['total_mt']))
-    isomer_dict = tp.determine_all_excitations(tendl_path, MTs)
+    isomer_dict = tp.determine_all_excitations(endf_dict, MTs)
 
     return MTs, isomer_dict, njoy_error, unresr_err_cases
 
@@ -430,7 +427,7 @@ def rxn_to_str(parent, daughter, MT, rxn):
     return dsv_row + ' '.join(str(xs) for xs in rxn['xsections'])
 
 def store_results(
-    dsv_path, all_rxns, nGroups, tendl_dir, group_name, plotting
+    dsv_path, all_rxns, nGroups, tendl_dir, group_name, plotting, endf_dict
 ):
     """
     Save groupwise-converted cross-section data to a space-delimited DSV file
@@ -474,7 +471,9 @@ def store_results(
             cross-sections.
         plotting (bool): Boolean to set whether to produce cross-section
             plots.
-
+        endf_dict (dict): Nested EndfParserPy-formatted dictionary containing
+            all parsed nuclear data from a TENDL file.
+            
     Returns:
         None 
     """
@@ -483,9 +482,6 @@ def store_results(
         dsv.write(f'{nGroups} {group_name}\n')
         for parent in sorted(all_rxns):
             element, A = tp.interpret_KZA(parent)
-            endf_dict = EndfParserPy().parsefile(
-                tendl_dir / f'{element}{A}.tendl'
-            )
             for daughter in all_rxns[parent]:
                 if parent != daughter:
                     for MT, rxn in all_rxns[parent][daughter].items():
@@ -584,8 +580,8 @@ def main():
     for file_properties in tp.search_for_files(search_dir):
         element, A, pKZA, endf_path = tuple(file_properties.values())
         TAPE20.write_bytes(endf_path.read_bytes())
-        endf_file_dict, material_id = tp.parse_endf_file_level_data(TAPE20)
-        MTs = set(endf_file_dict)
+        endf_dict, mf3_file_dict, material_id = tp.parse_endf_data(TAPE20)
+        MTs = set(mf3_file_dict)
 
         if len((MTs - rxd.SPEC_MTS) - endf6_MTs) > 0:
             invalid_MTs = sorted((MTs - rxd.SPEC_MTS) - endf6_MTs)
@@ -597,7 +593,7 @@ def main():
 
         MTs, isomer_dict, njoy_prep_error, unresr_err_cases = process_pendf(
             material_id, MTs, pKZA, mt_dict, temperature,
-            TAPE20, search_dir, unresr_err_cases
+            endf_dict, search_dir, unresr_err_cases
         )
 
         if not njoy_prep_error:
@@ -631,7 +627,7 @@ def main():
     dsv_path = dir / 'cumulative_gendf_data.dsv'
     store_results(
         dsv_path, gas_filtered, nGroups,
-        search_dir, group_name, args.xs_plotting 
+        search_dir, group_name, args.xs_plotting, endf_dict
     )
     print(
         f'Neutron activation cross-sections converted to {nGroups} groups ' \

--- a/tools/ALARAJOYWrapper/tendl_processing.py
+++ b/tools/ALARAJOYWrapper/tendl_processing.py
@@ -23,6 +23,7 @@ REVERSE_EXCITATION_DICT = {
     for val in arr
 }
 ISOMERIC_STATES = 'mnopqrstuvwxyz'
+PATH_SPECIFIC_MFS = (9,10)
 
 def parse_endf_file_level_data(endf_path, MF=3, endf_format='endf6-ext'):
     """
@@ -187,10 +188,9 @@ def determine_all_excitations(endf_path, MTs):
 
     isomer_dict = defaultdict(lambda: defaultdict(list))
 
-    path_specific_MFs = (9,10)
     mf_dict = {
         MF: parse_endf_file_level_data(endf_path, MF)[0]
-        for MF in path_specific_MFs
+        for MF in PATH_SPECIFIC_MFS
     }
 
     for MT in MTs:
@@ -199,7 +199,7 @@ def determine_all_excitations(endf_path, MTs):
             # Isomer pathways contained either in MF 9 ("Multiplicities for
             # Production of Radioactive Nuclides") and MF 10 ("Cross Sections
             # for Production of Radioactive Nuclides").
-            for MF in path_specific_MFs:
+            for MF in PATH_SPECIFIC_MFS:
                 pathways = mf_dict[MF].get(MT, {}).get('subsection', {})
                 for pathway_data in pathways.values():
                     isomer_dict[MT][MF].append(pathway_data['LFS'])

--- a/tools/ALARAJOYWrapper/tendl_processing.py
+++ b/tools/ALARAJOYWrapper/tendl_processing.py
@@ -25,7 +25,7 @@ REVERSE_EXCITATION_DICT = {
 ISOMERIC_STATES = 'mnopqrstuvwxyz'
 PATH_SPECIFIC_MFS = (9,10)
 
-def parse_endf_file_level_data(endf_path, MF=3, endf_format='endf6-ext'):
+def parse_endf_data(endf_path, MF=3, endf_format='endf6-ext'):
     """
     For an ENDF-formatted TENDL file containing neutron activation data for a
         single nuclide, parse and store the file's data into a nested
@@ -53,7 +53,29 @@ def parse_endf_file_level_data(endf_path, MF=3, endf_format='endf6-ext'):
     
     endf_dict = EndfParserPy(endf_format=endf_format).parsefile(endf_path)
 
-    return endf_dict.get(MF, {}), endf_dict[1][451]['MAT']
+    return endf_dict, endf_dict.get(MF, {}), endf_dict[1][451]['MAT']
+
+def get_section_dict(endf_dict, MF, MT):
+    """
+    Produce a reaction (MT)-specific subdictionary from a nested EndfParserPy-
+        formatted nested dictionary containing a whole TENDL file's parsed
+        nuclear data. Will return an empty dictionary if either the MF or MT
+        are not present in the provided dictionary.
+
+    Arguments:
+        endf_dict (dict): Nested EndfParserPy-formatted dictionary containing
+            all parsed nuclear data from a TENDL file.
+        MF (int): ENDF file number.
+        MT (int): Unique reaction identifier.
+
+    Returns:
+        section (dict): Sub-dictionary containing nuclear data for a
+            given MF/MT combination from a parsed TENDL file. Will return an
+            empty dictionary if either the MF or MT is not present in
+            `endf_dict`.
+    """
+
+    return endf_dict.get(MF, {}).get(MT, {})
 
 def calculate_KZA_from_ENDF(filepath, MF=1, MT=451):
     """
@@ -77,7 +99,7 @@ def calculate_KZA_from_ENDF(filepath, MF=1, MT=451):
         KZA (int): Unique ZZZAAAM identifier for a given nuclide.
     """
 
-    nuc_data = parse_endf_file_level_data(filepath, MF)[0][MT]
+    nuc_data = parse_endf_data(filepath, MF)[1][MT]
 
     return int(nuc_data['ZA'] * 10 + nuc_data['LISO'])
 
@@ -162,7 +184,7 @@ def search_for_files(dir = Path.cwd()):
 
     return file_info
 
-def determine_all_excitations(endf_path, MTs):
+def determine_all_excitations(endf_dict, MTs):
     """
     Reference an ENDF file's MF9 and MF10 file data and explicitly defined
         excitation reactions to construct a nested dictionary keyed by
@@ -173,8 +195,8 @@ def determine_all_excitations(endf_path, MTs):
         cross-section data.
 
     Arguments:
-        endf_path (pathlib._local.PosixPath): Path to the ENDF (TENDL) file to
-            be processed.
+        endf_dict (dict): Nested EndfParserPy-formatted dictionary containing
+            all parsed nuclear data from a TENDL file.
         MTs (set): Set of all MT reaction numbers contained in the TENDL file.
 
     Returns:
@@ -188,11 +210,6 @@ def determine_all_excitations(endf_path, MTs):
 
     isomer_dict = defaultdict(lambda: defaultdict(list))
 
-    mf_dict = {
-        MF: parse_endf_file_level_data(endf_path, MF)[0]
-        for MF in PATH_SPECIFIC_MFS
-    }
-
     for MT in MTs:
         cumulative_MT = REVERSE_EXCITATION_DICT.get(MT)
         if MT not in EXCITATION_REACTIONS:
@@ -200,7 +217,9 @@ def determine_all_excitations(endf_path, MTs):
             # Production of Radioactive Nuclides") and MF 10 ("Cross Sections
             # for Production of Radioactive Nuclides").
             for MF in PATH_SPECIFIC_MFS:
-                pathways = mf_dict[MF].get(MT, {}).get('subsection', {})
+                pathways = get_section_dict(
+                    endf_dict, MF, MT
+                ).get('subsection', {})
                 for pathway_data in pathways.values():
                     isomer_dict[MT][MF].append(pathway_data['LFS'])
 

--- a/tools/ALARAJOYWrapper/xs_plotting.py
+++ b/tools/ALARAJOYWrapper/xs_plotting.py
@@ -26,14 +26,15 @@ def flagged_num_to_int(num):
             instance of '*' contained in the original value.
     """
 
-    re_match = re.match(r'^-?\d+', str(num))
+    num = str(num)
+    re_match = re.match(r'^-?\d+', num)
     if not re_match:
         raise ValueError(
             f'Invalid flagged number {num}. Must be formatted with numeric ' \
             'characters before non-numeric characters.'
         )
-    
-    return int(re_match.group())
+
+    return int(re_match.group()), '*' * num.count('*')
 
 def ensure_emission_specificity(emitted, dKZA):
     """

--- a/tools/ALARAJOYWrapper/xs_plotting.py
+++ b/tools/ALARAJOYWrapper/xs_plotting.py
@@ -6,6 +6,7 @@ import njoy_tools as njt
 import reaction_data as rxd
 import matplotlib.pyplot as plt
 from pathlib import Path
+from endf_parserpy import EndfParserPy
 
 def flagged_num_to_int(num):
     """
@@ -34,7 +35,7 @@ def flagged_num_to_int(num):
             'characters before non-numeric characters.'
         )
 
-    return int(re_match.group()), '*' * num.count('*')
+    return int(re_match.group()), num.count('*')
 
 def ensure_emission_specificity(emitted, dKZA):
     """
@@ -62,14 +63,147 @@ def ensure_emission_specificity(emitted, dKZA):
 
     return emitted
 
-def extract_continuous_data(tendl_path, MT):
+def get_section_dict(endf_dict, MF, MT):
+    """
+    Produce a reaction (MT)-specific subdictionary from a nested EndfParserPy-
+        formatted nested dictionary containing a whole TENDL file's parsed
+        nuclear data. Will return an empty dictionary if either the MF or MT
+        are not present in the provided dictionary.
+
+    Arguments:
+        endf_dict (dict): Nested EndfParserPy-formatted dictionary containing
+            all parsed nuclear data from a TENDL file.
+        MF (int): ENDF file number.
+        MT (int): Unique reaction identifier.
+
+    Returns:
+        section (dict): Sub-dictionary containing nuclear data for a
+            given MF/MT combination from a parsed TENDL file. Will return an
+            empty dictionary if either the MF or MT is not present in
+            `endf_dict`.
+    """
+
+    return endf_dict.get(MF, {}).get(MT, {})
+
+def vectorize_tab1(endf_dict={}, MT=0, pathway_data={}):
+    """
+    Interpret and reformat ENDF6 TAB1 data into a 1-D array for a specific
+        reaction. This can be done for any ENDF MF (file), with different
+        input requirements for MF3 versus MF9. TAB1 formatting is based on
+        the ENDF-6 manual
+        (https://www.nndc.bnl.gov/endfdocs/ENDF-102-2023.pdf). NJOY's
+        endf.terpa() TAB1 interpolation function necessitates the array
+        formatting of TAB1 data that vectorize_tab1() outputs, which is
+        necessary to produce matching energies and energy-dependent values
+        between MF3 and MF9 for a given reaction to produce excitation
+        pathway-specific cross-sections from the multiplication of MF3
+        cumulative cross-sections with MF9 multiplicites.
+
+        MF3 ('Reaction Cross Sections'):
+            The TAB1 formatting for MF3 is as follows:
+                [QM, QI, 0, LR, NR, NP/ E_int/ sigma(E)]
+            Descriptions of each of these values can be found in section 3.2
+            ('Formats') of the ENDF6 manual.
+            
+            To vectorize this TAB1 data, an EndfParserPy-formatted nested
+            dictionary containing a whole TENDL file's parsed nuclear data
+            must be provided as the `endf_dict` argument and the specific
+            reaction type as the `MT` argument.
+
+        MF 9 ('Multiplicities for Production of Radioactive Nuclides'):
+
+            The TAB1 formatting for MF9/10 is as follows:
+                [QM, QI, IZAP, LFS, NR, NP/ E_int / Y(E)]
+            Descriptions of each of these values can be found in section 9.2
+            ('Formats') of the ENDF6 manual.
+
+            To vectorize this TAB1 data, a subdictionary of an EndfParserPy-
+            formatted nested dictionary must be supplied for a specific
+            reaction, parent-daughter pathway. Because MF9 contains specific
+            daughter excitation pathways for a given reaction, these
+            'subsections' are contained in their own dictionaries in the
+            EndfParserPy dictionary structure below the `MT` key. Such a
+            subdictionary must be provided as the `pathway_data` argument.
+
+    Arguments:
+        endf_dict (dict, optional): Nested EndfParserPy-formatted dictionary
+            containing all parsed nuclear data from a TENDL file. Only
+            necessary for MF3.
+            (Defaults to {})
+        MT (int, optional): Unique reaction identifier. Only necessary for
+            MF3.
+            (Defaults to 0)
+        pathway_data (dict, optional): Dictionary containing the TAB1 data for
+            a specific MF9, MT reaction pathway to a specified daughter
+            nuclide. Only necessary for MF9.
+            (Defaults to {})
+
+    Returns:
+        tab1_array (numpy.ndarray): 1-D array of the reaction's TAB1 data from
+            the implied MF handling scheme.
+    """
+
+    if (not endf_dict and MT == 0) and not pathway_data:
+        raise TypeError(
+            'Must supply either supply endf_dict and MT arguments together ' \
+            'or pathway_data individually.'
+        )
+
+    # MF 9
+    if pathway_data:
+        nbt     = np.asarray(pathway_data['NBT'])
+        ints    = np.asarray(pathway_data['INT'])
+        ninterp = len(nbt)
+        npoints = len(pathway_data['E'])
+        header  = np.array([
+            pathway_data['QM'],
+            pathway_data['QI'],
+            pathway_data['IZAP'],
+            pathway_data['LFS'],
+            ninterp,
+            npoints
+        ])
+        energy_arr           = pathway_data['E']
+        energy_dependent_var = pathway_data['Y']
+
+    # MF 3
+    else:
+        section  = get_section_dict(endf_dict, 3, MT)
+        xs_table = section.get('xstable')
+        
+        nbt      = np.asarray(xs_table['NBT'])
+        ints     = np.asarray(xs_table['INT'])
+        ninterp  = len(nbt)
+        npoints  = len(xs_table['E'])
+        header   = np.array([
+            section['QM'],
+            section['QI'],
+            0,
+            section['LR'],
+            ninterp,
+            npoints
+        ])
+        energy_arr           = xs_table['E']
+        energy_dependent_var = xs_table['xs']
+
+    interpolation_scheme = np.empty(2 * ninterp)
+    interpolation_scheme[::2]  = nbt
+    interpolation_scheme[1::2] = ints
+
+    tabular_data = np.empty(2 * npoints)
+    tabular_data[::2]  = energy_arr
+    tabular_data[1::2] = energy_dependent_var
+
+    return np.concatenate([header, interpolation_scheme, tabular_data])
+
+def extract_continuous_data(endf_dict, MT):
     """
     For a given nuclide and reaction, extract its continuous-energy cross-
         sections and corresponding energies from its original TENDL file.
 
     Arguments:
-        tendl_path (pathlib._local.PosixPath): Path to the nuclide's original
-            TENDL file.
+        endf_dict (dict): Nested EndfParserPy-formatted dictionary containing
+            all parsed nuclear data from a TENDL file.
         MT (int): Reaction identifying number.
 
     Returns:
@@ -84,16 +218,53 @@ def extract_continuous_data(tendl_path, MT):
             lists.
     """
 
-    xs_table = (
-        tp.parse_endf_file_level_data(tendl_path)[0]
-        .get(MT, {})
-        .get('xstable', {'E' : [], 'xs' : []})
-    )
+    continuous_dict = dict()
+    MT, isomeric_state = flagged_num_to_int(MT)
 
-    return {
-        'xs'         :   xs_table['xs'],
-        'energies'   :    xs_table['E']
-    }
+    if isomeric_state > 0:
+        for MF in tp.PATH_SPECIFIC_MFS:
+            subsection = get_section_dict(endf_dict, MF, MT).get('subsection')
+            if subsection and isomeric_state < len(subsection):
+                pathway_data = subsection[list(subsection)[isomeric_state]]
+                continuous_dict['energies'] = pathway_data['E']
+
+                # Calculate interpolated proportional cross-section from MF3
+                # cumulative cross-sections and MF9 multiplicities
+                if MF == 9:
+                    njoy_endf_wrapper = njt.import_njoy_endf_wrapper()
+
+                    mf3_tab1 = vectorize_tab1(endf_dict=endf_dict, MT=MT)
+                    mf3_interpolated_xs = njoy_endf_wrapper.interpolate_tab1(
+                        mf3_tab1, pathway_data['E']
+                    )
+
+                    mf9_tab1 = vectorize_tab1(pathway_data=pathway_data)
+                    mf9_interpolated_multiplicities = (
+                        njoy_endf_wrapper.interpolate_tab1(
+                            mf9_tab1, pathway_data['E']
+                        )
+                    )
+
+                    continuous_dict['xs'] = (
+                        mf3_interpolated_xs * mf9_interpolated_multiplicities
+                    )
+                    break
+                
+                # MF10 cross-sections can be extracted directly without need
+                # for interpolation
+                else:
+                    continuous_dict['xs'] = pathway_data['sigma']
+
+    # For non-excitation reactions, cross-sections can be extracted directly
+    # from MF3
+    else:
+        xs_table = get_section_dict(
+            endf_dict, 3, MT
+        ).get('xstable', {'E' : [], 'xs' : []})
+        continuous_dict['xs'] = xs_table['xs']
+        continuous_dict['energies'] = xs_table['E']
+
+    return continuous_dict
 
 def extract_groupwise_data_from_DSV(dsv_list, KZA, MT):
     """
@@ -142,14 +313,14 @@ def extract_groupwise_data_from_DSV(dsv_list, KZA, MT):
             dsv_pKZA, dsv_dKZA, dsv_MT, emitted = rxn[:4]
             emitted = ensure_emission_specificity(emitted, dsv_dKZA)
 
-            if KZA == dsv_pKZA and MT == flagged_num_to_int(dsv_MT)[0]:
+            if KZA == dsv_pKZA and str(MT) == dsv_MT:
                 groupwise_dict[group_name] = {
                     'xs'          :    np.array(rxn[4:]).astype(float),
                     'energies'    :    energy_bounds
                 }
                 break
 
-    return groupwise_dict, ensure_emission_specificity(emitted, dsv_dKZA)
+    return groupwise_dict, emitted
 
 def set_plot_save_path(
     element, A, emitted, tendl_dir, group_names, img_ext='png'
@@ -349,7 +520,35 @@ def find_all_mass_nums(tendl_dir, element):
             mass_nums.add(nuc_match.group(1))
 
     return mass_nums
+
+def find_all_MTs(dsv_list, pKZA):
+    """
+    Given a list of preprocessed groupwise DSV files and a parent nuclide
+        identified by its KZA, compile all reaction identifiers (MTs) that
+        exist for that nuclide in any of the DSVs.
+
+    Arguments:
+        dsv_list (list): List of filepaths to DSV files containing
+            ALARAJOYWrapper-processed groupwise TENDL data.
+        pKZA (int): ZZZAAAM identifier of the parent nuclide.
+
+    Returns:
+        MTs (set): Set of all reaction types for the parent nuclide present in
+            any of the DSV files provided.
+    """
+
+    MTs = set()
+    for dsv in dsv_list:
+        with open(dsv, 'r') as f:
+            dsv_lines = f.readlines()
+
+        for line in dsv_lines[1:-1]:
+            rxn = line.split()
+            if rxn[0] == str(pKZA):
+                MTs.add(rxn[2])
     
+    return MTs
+
 def main():
 
     # Only load in yaml module when executing xs_plotting.py as a script,
@@ -394,8 +593,12 @@ def main():
             mass_nums = find_all_mass_nums(tendl_dir, element)
 
         for A in mass_nums:
+            endf_dict = EndfParserPy().parsefile(
+                tendl_dir / f'{element}{A}.tendl'
+            )
+
             KZA = str((
-                njt.elements[element] * 1000 + flagged_num_to_int(A)
+                njt.elements[element] * 1000 + flagged_num_to_int(A)[0]
             ) * 10 + tp.ISOMERIC_STATES.find(str(A)[-1]) + 1)
 
             MTs = adjust_dict_for_all_tag(element_dict, A)
@@ -404,17 +607,12 @@ def main():
                 MTs = [MTs]
     
             if check_all_tag(MTs):
-                MTs = rxd.process_mt_data(rxd.load_mt_table(
-                    njt.set_directory() / 'mt_table.csv'
-                )).keys()
+                MTs = find_all_MTs(dsv_list, KZA)
 
-            for MT in [flagged_num_to_int(MT) for MT in MTs]:
+            for MT in MTs:
                 fig, ax = plt.subplots(figsize=(10,6))
                 
-                continuous_dict = extract_continuous_data(
-                    tendl_dir / f'{element}{A}.tendl', flagged_num_to_int(MT)
-                )
-
+                continuous_dict = extract_continuous_data(endf_dict, MT)
                 groupwise_dict, emitted = extract_groupwise_data_from_DSV(
                     dsv_list, KZA, MT
                 )

--- a/tools/ALARAJOYWrapper/xs_plotting.py
+++ b/tools/ALARAJOYWrapper/xs_plotting.py
@@ -63,28 +63,6 @@ def ensure_emission_specificity(emitted, dKZA):
 
     return emitted
 
-def get_section_dict(endf_dict, MF, MT):
-    """
-    Produce a reaction (MT)-specific subdictionary from a nested EndfParserPy-
-        formatted nested dictionary containing a whole TENDL file's parsed
-        nuclear data. Will return an empty dictionary if either the MF or MT
-        are not present in the provided dictionary.
-
-    Arguments:
-        endf_dict (dict): Nested EndfParserPy-formatted dictionary containing
-            all parsed nuclear data from a TENDL file.
-        MF (int): ENDF file number.
-        MT (int): Unique reaction identifier.
-
-    Returns:
-        section (dict): Sub-dictionary containing nuclear data for a
-            given MF/MT combination from a parsed TENDL file. Will return an
-            empty dictionary if either the MF or MT is not present in
-            `endf_dict`.
-    """
-
-    return endf_dict.get(MF, {}).get(MT, {})
-
 def vectorize_tab1(endf_dict={}, MT=0, pathway_data={}):
     """
     Interpret and reformat ENDF6 TAB1 data into a 1-D array for a specific
@@ -168,7 +146,7 @@ def vectorize_tab1(endf_dict={}, MT=0, pathway_data={}):
 
     # MF 3
     else:
-        section  = get_section_dict(endf_dict, 3, MT)
+        section  = tp.get_section_dict(endf_dict, 3, MT)
         xs_table = section.get('xstable')
         
         nbt      = np.asarray(xs_table['NBT'])
@@ -223,7 +201,9 @@ def extract_continuous_data(endf_dict, MT):
 
     if isomeric_state > 0:
         for MF in tp.PATH_SPECIFIC_MFS:
-            subsection = get_section_dict(endf_dict, MF, MT).get('subsection')
+            subsection = tp.get_section_dict(
+                endf_dict, MF, MT
+            ).get('subsection')
             if subsection and isomeric_state < len(subsection):
                 pathway_data = subsection[list(subsection)[isomeric_state]]
                 continuous_dict['energies'] = pathway_data['E']
@@ -258,7 +238,7 @@ def extract_continuous_data(endf_dict, MT):
     # For non-excitation reactions, cross-sections can be extracted directly
     # from MF3
     else:
-        xs_table = get_section_dict(
+        xs_table = tp.get_section_dict(
             endf_dict, 3, MT
         ).get('xstable', {'E' : [], 'xs' : []})
         continuous_dict['xs'] = xs_table['xs']


### PR DESCRIPTION
Follows #305.

Following additional file parsing instance for continuous data extraction for plotting within `preprocess_fendl3.store_results()` from #305, this PR changes the function `tendl_processing.parse_endf_file_level_data()` to now be called `tendl_processing.parse_endf_data()`, with the major functional change being the return of the entire parsed nested dictionary. This creates a stored variable in memory, `endf_dict` that already contains all of the nuclear data from a single nuclide's TENDL file, without requiring that the file be parsed a second time for plotting.