### PR TITLE
Single neutron energy vertical line option in xs_plotting

### DIFF
--- a/tools/ALARAJOYWrapper/xs_plotting.py
+++ b/tools/ALARAJOYWrapper/xs_plotting.py
@@ -7,23 +7,6 @@ import reaction_data as rxd
 import matplotlib.pyplot as plt
 from pathlib import Path
 
-CONVERSION_DICT = {
-    'a' : 1e-18,
-    'f' : 1e-15,
-    'p' : 1e-12,
-    'n' : 1e-9,
-    'u' : 1e-6, # Accepts u or "μ" for micro-
-    'μ' : 1e-6, # Accepts u or "μ" for micro-
-    'm' : 1e-3,
-    'c' : 1e-2,
-    'k' : 1e3,
-    'M' : 1e6,
-    'G' : 1e9,
-    'T' : 1e12,
-    'P' : 1e15,
-    'E' : 1e18
-}
-
 def flagged_num_to_int(num):
     """
     Convert numerical values that may be in string form containing additional
@@ -298,6 +281,63 @@ def plot_single_nuc_rxn_xs(
 
     return ax    
 
+def convert_to_eV(energy_vline_arg, parser=None):
+    """
+    Convert an energy value to units of electron-volts, if it is specified to
+        be in some SI multiple of eV (i.e. MeV).
+
+    Arguments:
+        energy_vline_arg (list of str): List specifying the neutron energy to
+            denote with a vertical line. If only a single value is provided,
+            then eV units will be assumed. Otherwise, any SI unit prefix can
+            be supplied as the second value in the list, to be converted
+            internally to eV (i.e. ['14.1', 'MeV'] will be converted to
+            1.41e+07 eV).
+        parser (argparser.ArgumentParser, optional): Option to include the
+            argparser ArgumentParser object through which to channel
+            improperly supplied `energy_vline_arg` values. Needed if being
+            called within `main()`.
+            (Defaults to None)
+
+    Returns:
+        converted_energy (float): Energy value in electron-volts      
+    """
+
+    conversion_dict = {
+        'a' : 1e-18,
+        'f' : 1e-15,
+        'p' : 1e-12,
+        'n' : 1e-9,
+        'u' : 1e-6, # Accepts u or "μ" for micro-
+        'μ' : 1e-6, # Accepts u or "μ" for micro-
+        'm' : 1e-3,
+        'c' : 1e-2,
+        'k' : 1e3,
+        'M' : 1e6,
+        'G' : 1e9,
+        'T' : 1e12,
+        'P' : 1e15,
+        'E' : 1e18
+    }
+
+    vline_energy = float(energy_vline_arg[0])
+    if len(energy_vline_arg) == 2:
+        energy_units = energy_vline_arg[1]
+    elif len(energy_vline_arg) > 2:
+        error_message = (
+            'Too many values for energy_vline. ' \
+            'Can provide upt to two values: energy, energy_units'
+        )
+        if parser:
+            parser.error(error_message)
+        else:
+            raise TypeError(error_message)
+
+    if energy_units and energy_units.lower() != 'eV':
+        vline_energy *= conversion_dict[energy_units[0]]
+
+    return vline_energy
+
 def plot_neutron_energy_axvline(ax, energy_vline_arg, parser=None):
     """
     Given a pre-exisisting Matplotlib Axes object, include a vertical line at
@@ -323,22 +363,7 @@ def plot_neutron_energy_axvline(ax, energy_vline_arg, parser=None):
             plot being constructed.
     """
 
-    vline_energy = float(energy_vline_arg[0])
-    if len(energy_vline_arg) == 2:
-        energy_units = energy_vline_arg[1]
-    elif len(energy_vline_arg) > 2:
-        error_message = (
-            'Too many values for energy_vline. ' \
-            'Can provide upt to two values: energy, energy_units'
-        )
-        if parser:
-            parser.error(error_message)
-        else:
-            raise TypeError(error_message)
-
-    if energy_units and energy_units.lower() != 'eV':
-        vline_energy *= CONVERSION_DICT[energy_units[0]]
-
+    vline_energy = convert_to_eV(energy_vline_arg, parser)
     ax.axvline(
         vline_energy,
         color='r', 

--- a/tools/ALARAJOYWrapper/xs_plotting.py
+++ b/tools/ALARAJOYWrapper/xs_plotting.py
@@ -7,6 +7,23 @@ import reaction_data as rxd
 import matplotlib.pyplot as plt
 from pathlib import Path
 
+CONVERSION_DICT = {
+    'a' : 1e-18,
+    'f' : 1e-15,
+    'p' : 1e-12,
+    'n' : 1e-9,
+    'u' : 1e-6, # Accepts u or "μ" for micro-
+    'μ' : 1e-6, # Accepts u or "μ" for micro-
+    'm' : 1e-3,
+    'c' : 1e-2,
+    'k' : 1e3,
+    'M' : 1e6,
+    'G' : 1e9,
+    'T' : 1e12,
+    'P' : 1e15,
+    'E' : 1e18
+}
+
 def flagged_num_to_int(num):
     """
     Convert numerical values that may be in string form containing additional
@@ -278,7 +295,57 @@ def plot_single_nuc_rxn_xs(
     ax.set_ylabel('Cross-Section [b]')
     ax.set_title(title)
     ax.grid()
-    ax.legend()
+
+    return ax    
+
+def plot_neutron_energy_axvline(ax, energy_vline_arg, parser=None):
+    """
+    Given a pre-exisisting Matplotlib Axes object, include a vertical line at
+        a specified energy to highlight the cross-section data in that region.
+    
+    Arguments:
+        ax (matplotlib.axes._axes.Axes): Matplotlib Axes object of the plot
+            being constructed.
+        energy_vline_arg (list of str): List specifying the neutron energy to
+            denote with a vertical line. If only a single value is provided,
+            then eV units will be assumed. Otherwise, any SI unit prefix can
+            be supplied as the second value in the list, to be converted
+            internally to eV (i.e. ['14.1', 'MeV'] will be converted to
+            1.41e+07 eV).
+        parser (argparser.ArgumentParser, optional): Option to include the
+            argparser ArgumentParser object through which to channel
+            improperly supplied `energy_vline_arg` values. Needed if being
+            called within `main()`.
+            (Defaults to None)
+
+    Returns:
+        ax (matplotlib.axes._axes.Axes): Updated Matplotlib Axes object of the
+            plot being constructed.
+    """
+
+    vline_energy = float(energy_vline_arg[0])
+    if len(energy_vline_arg) == 2:
+        energy_units = energy_vline_arg[1]
+    elif len(energy_vline_arg) > 2:
+        error_message = (
+            'Too many values for energy_vline. ' \
+            'Can provide upt to two values: energy, energy_units'
+        )
+        if parser:
+            parser.error(error_message)
+        else:
+            raise TypeError(error_message)
+
+    if energy_units and energy_units.lower() != 'eV':
+        vline_energy *= CONVERSION_DICT[energy_units[0]]
+
+    ax.axvline(
+        vline_energy,
+        color='r', 
+        alpha=0.4, 
+        label=f'{vline_energy:.2e} eV',
+        linestyle='--'
+    )
 
     return ax
 
@@ -360,6 +427,9 @@ def main():
 
     parser = argparse.ArgumentParser()
     parser.add_argument('--yaml', '-y')
+    parser.add_argument(
+        '--energy_vline', '-e', nargs='*'
+    )
     args = parser.parse_args()
 
     with open(args.yaml, 'r') as f:
@@ -423,9 +493,16 @@ def main():
                         ax, element, A, emitted,
                         continuous_dict, groupwise_dict
                     )
+                    if args.energy_vline:
+                        plot_neutron_energy_axvline(
+                            ax, args.energy_vline, parser=parser
+                        )
+
                     plot_path = set_plot_save_path(
                         element, A, emitted, tendl_dir, groupwise_dict.keys()
                     )
+
+                    ax.legend()
                     plt.savefig(plot_path)
 
     print(


### PR DESCRIPTION
This PR introduces new functionality to `xs_plotting.py` to allow for the plotting of a vertical line at a provided neutron energy to highlight the plot in a specific region. This was motivated by the desire to see the differences in group structure effects for 14.1 MeV neutrons by having a clear marker of where on the plot to focus.