### PR TITLE
ALARAPlot: Replacing Legend Object with Its Associated Figure 

### DIFF
--- a/tools/alara_output_processing/alara_output_plotting.py
+++ b/tools/alara_output_processing/alara_output_plotting.py
@@ -82,7 +82,7 @@ def preprocess_data(
 
     if nuclides:
         filter_dict['nuclide'] = nuclides
-    
+
     filtered = adf.filter_rows(filter_dict)
 
     if half_lives is not None:
@@ -225,8 +225,8 @@ def construct_legend(ax, legend_ax=None):
             object than the plot itself.
     
     Returns:
-        legend (matplotlib.legend.Legend): Matplotlib Legend object containing
-            the constructed legend.
+        legend (matplotlib.figure.Figure): Matplotlib Figure object to which
+            the constructed legend belongs.
     '''
 
     handles, labels = ax.get_legend_handles_labels()
@@ -273,7 +273,7 @@ def construct_legend(ax, legend_ax=None):
         handletextpad=0.5,
     )
 
-    return legend
+    return legend.get_figure()
 
 def plot_or_scatter(plot_type, ax, x, y, label, color, style):
     '''


### PR DESCRIPTION
This PR makes a small change to the function `alara_output_processing.alara_output_plotting.construct_legend()` to return the associated `matplotlib.figure.Figure()` object for the legend rather than the `matplotlib.legend.Legend()` itself.

Previously, when I had been just producing all of the plots for my "Activation Handbook" validation in a Jupyter Notebook, the associated figures for these legends would still appear by virtue of Matplotlib's interfacing with the Jupyter environment. As I've been working to move the workflow into an automated process with LaTeX scripting, I've been saving all figures as PNG files. This led me to realize that in order to do this, the Matplotlib function `savefig()` can only be called on a Figure object, not a Legend. Given that the Legend object was already not being used for itself but only to effectively provide a wrapper for its associated Figure, this change is very minor and simply allows the legend to be interacted with in the way that I already thought it was supposed to be doing.