### PR TITLE
Patching ALARAPlot bug for mismatching nuclides in control vs comparison runs for ratio plotting

### DIFF
--- a/tools/alara_output_processing/alara_output_plotting.py
+++ b/tools/alara_output_processing/alara_output_plotting.py
@@ -868,6 +868,13 @@ def plot_single_response(
 
             series = piv.loc[nuc].to_numpy()
             if ratio_plotting:
+                if nuc not in control_piv.index:
+                    warn(
+                        f'{nuc.capitalize()} present in {run_lbl}' \
+                        f'but not in {control_run}. Skipping.'
+                    )
+                    continue
+
                 series /= control_piv.loc[nuc].to_numpy()
                 if not np.isnan(series.mean()) and nuc == 'total':
                     label_suffix += (


### PR DESCRIPTION
This PR patches a bug in `alara_output_processing.alara_output_plotting.plot_single_response()`, wherein if the function was being called to create a ratio plot between two or more data sets, if the control (divisor) data set was missing a nuclide, a `KeyError` would be raised. This is resolved by checking against the index of the `control_piv` before calling `series /= control_piv.loc[nuc].to_numpy()` and if missing, will provide a warning and then `continue`.